### PR TITLE
refactor(utils): make more generic functions for fetching blockchain events

### DIFF
--- a/scripts/calculateRevenue/protocols/beefy/types.ts
+++ b/scripts/calculateRevenue/protocols/beefy/types.ts
@@ -2,11 +2,6 @@ import { BeefyInvestorTransaction } from '../../../protocolFilters/beefy'
 import { Address } from 'viem'
 import { NetworkId } from '../../../types'
 
-export interface BlockTimestampData {
-  height: number
-  timestamp: number
-}
-
 export interface FeeEvent {
   beefyFee: number | bigint
   timestamp: Date

--- a/scripts/calculateRevenue/protocols/types.ts
+++ b/scripts/calculateRevenue/protocols/types.ts
@@ -1,0 +1,4 @@
+export interface BlockTimestampData {
+  height: number
+  timestamp: number
+}

--- a/scripts/calculateRevenue/protocols/utils/events.test.ts
+++ b/scripts/calculateRevenue/protocols/utils/events.test.ts
@@ -1,0 +1,105 @@
+import { _fetchEvents, _getNearestBlock } from './events'
+import nock from 'nock'
+import { NetworkId } from '../../../types'
+import { BlockTimestampData } from '../types'
+import { getViemPublicClient } from '../../../utils'
+import { erc20Abi, GetContractReturnType } from 'viem'
+
+jest.mock('../utils/viem')
+jest.mock('../../../utils')
+
+describe('On-chain event helpers', () => {
+  describe('getNearestBlock', () => {
+    it('should correctly fetch the nearest block to a given timestamp', async () => {
+      const mockBlockTimestamp: BlockTimestampData = {
+        timestamp: 1234,
+        height: 345,
+      }
+      nock(`https://coins.llama.fi`)
+        .get(`/block/arbitrum/1736525692`)
+        .reply(200, mockBlockTimestamp)
+
+      const networkId = NetworkId['arbitrum-one']
+      const timestamp = new Date(1736525692000)
+      const result = await _getNearestBlock(networkId, timestamp)
+
+      expect(result).toEqual(345)
+    })
+  })
+  describe('fetchEvents', () => {
+    it('should fetch all events over multiple requests', async () => {
+      const mockGetContractEvents = jest
+        .fn()
+        .mockImplementation(({ fromBlock }: { fromBlock: bigint }) => {
+          return [
+            {
+              blockNumber: fromBlock,
+              args: {},
+              eventName: 'Swap',
+            },
+          ]
+        })
+      jest.mocked(getViemPublicClient).mockReturnValue({
+        getContractEvents: mockGetContractEvents,
+      } as unknown as ReturnType<typeof getViemPublicClient>)
+
+      const mockContract: GetContractReturnType = {
+        address: '0x123',
+        abi: erc20Abi,
+      }
+
+      const mockStartBlockTimestamp: BlockTimestampData = {
+        timestamp: 0,
+        height: 0,
+      }
+      const mockEndBlockTimestamp: BlockTimestampData = {
+        timestamp: 1000,
+        height: 15000,
+      }
+
+      nock(`https://coins.llama.fi`)
+        .get(`/block/arbitrum/0`)
+        .reply(200, mockStartBlockTimestamp)
+      nock(`https://coins.llama.fi`)
+        .get(`/block/arbitrum/1`)
+        .reply(200, mockEndBlockTimestamp)
+
+      const networkId = NetworkId['arbitrum-one']
+      const startTimestamp = new Date(0)
+      const endTimestamp = new Date(1000)
+      const result = await _fetchEvents({
+        contract: mockContract,
+        eventName: 'Swap',
+        networkId,
+        startTimestamp,
+        endTimestamp,
+      })
+
+      expect(mockGetContractEvents).toHaveBeenCalledTimes(2)
+      expect(mockGetContractEvents).toHaveBeenNthCalledWith(1, {
+        address: mockContract.address,
+        abi: mockContract.abi,
+        eventName: 'Swap',
+        fromBlock: 0n,
+        toBlock: 10000n,
+      })
+      expect(mockGetContractEvents).toHaveBeenNthCalledWith(2, {
+        address: mockContract.address,
+        abi: mockContract.abi,
+        eventName: 'Swap',
+        fromBlock: 10001n,
+        toBlock: 15000n,
+      })
+
+      expect(result).toHaveLength(2)
+
+      // Using toHaveProperty instead of toEqual because the blockNumber is a bigint
+      // and Jest doesn't handle bigint comparisons well
+
+      expect(result[0]).toHaveProperty('blockNumber', 0n)
+      expect(result[0]).toHaveProperty('eventName', 'Swap')
+      expect(result[1]).toHaveProperty('blockNumber', 10001n)
+      expect(result[1]).toHaveProperty('eventName', 'Swap')
+    })
+  })
+})

--- a/scripts/calculateRevenue/protocols/utils/events.ts
+++ b/scripts/calculateRevenue/protocols/utils/events.ts
@@ -1,0 +1,104 @@
+import { GetContractReturnType } from 'viem'
+import { NetworkId } from '../../../types'
+import { fetchWithTimeout } from '../../../utils/fetchWithTimeout'
+import memoize from '@github/memoize'
+import { getViemPublicClient } from '../../../utils'
+import { BlockTimestampData } from '../types'
+
+const DEFI_LLAMA_API_URL = 'https://coins.llama.fi'
+
+const NETWORK_ID_TO_DEFI_LLAMA_CHAIN: Partial<{
+  [networkId in NetworkId]: string // eslint-disable-line @typescript-eslint/no-unused-vars
+}> = {
+  [NetworkId['ethereum-mainnet']]: 'ethereum',
+  [NetworkId['arbitrum-one']]: 'arbitrum',
+  [NetworkId['op-mainnet']]: 'optimism',
+  [NetworkId['celo-mainnet']]: 'celo',
+  [NetworkId['polygon-pos-mainnet']]: 'polygon',
+  [NetworkId['base-mainnet']]: 'base',
+}
+
+/**
+ * Fetches the nearest block number for a given network and timestamp.
+ *
+ * @param networkId - The ID of the network to query.
+ * @param timestamp - The date and time for which to find the nearest block.
+ * @returns A promise that resolves to the block number closest to the given timestamp.
+ * @throws Will throw an error if the fetch request to DefiLlama fails.
+ */
+export async function _getNearestBlock(
+  networkId: NetworkId,
+  timestamp: Date,
+): Promise<number> {
+  const unixTimestamp = Math.floor(timestamp.getTime() / 1000)
+  const defiLlamaChain = NETWORK_ID_TO_DEFI_LLAMA_CHAIN[networkId]
+
+  const response = await fetchWithTimeout(
+    `${DEFI_LLAMA_API_URL}/block/${defiLlamaChain}/${unixTimestamp}`,
+  )
+  if (!response.ok) {
+    throw new Error(
+      `Error while fetching block timestamp from DefiLlama: ${response}`,
+    )
+  }
+  const blockTimestampData = (await response.json()) as BlockTimestampData
+  return blockTimestampData.height
+}
+
+export const getNearestBlock = memoize(_getNearestBlock, {
+  hash: (...params: Parameters<typeof _getNearestBlock>) => params.join(','),
+})
+
+/**
+ * Fetches events from a specified contract within a given time range.
+ *
+ * @param {Object} params - The parameters for fetching events.
+ * @param {GetContractReturnType} params.contract - The contract to fetch events from.
+ * @param {NetworkId} params.networkId - The network ID where the contract is deployed.
+ * @param {string} params.eventName - The name of the event to fetch.
+ * @param {Date} params.startTimestamp - The start timestamp for the event search.
+ * @param {Date} params.endTimestamp - The end timestamp for the event search.
+ * @returns {Promise<Log[]>} A promise that resolves to an array of event logs.
+ */
+export async function _fetchEvents({
+  contract,
+  networkId,
+  eventName,
+  startTimestamp,
+  endTimestamp,
+}: {
+  contract: GetContractReturnType
+  eventName: string
+  networkId: NetworkId
+  startTimestamp: Date
+  endTimestamp: Date
+}) {
+  const client = getViemPublicClient(networkId)
+
+  const startBlock = await getNearestBlock(networkId, startTimestamp)
+  const endBlock = await getNearestBlock(networkId, endTimestamp)
+  const blocksPer = 10000
+  let currentBlock = startBlock
+
+  const events = []
+
+  while (currentBlock <= endBlock) {
+    const toBlock = Math.min(currentBlock + blocksPer, endBlock)
+    const eventLogs = await client.getContractEvents({
+      address: contract.address,
+      abi: contract.abi,
+      eventName,
+      fromBlock: BigInt(currentBlock),
+      toBlock: BigInt(toBlock),
+    })
+
+    events.push(...eventLogs)
+    currentBlock = toBlock + 1
+  }
+  return events
+}
+
+export const fetchEvents = memoize(_fetchEvents, {
+  hash: (...params: Parameters<typeof _fetchEvents>) =>
+    Object.values(params[0]).join(','),
+})


### PR DESCRIPTION
Creates a more generic `fetchEvents` function to fetch all events of a certain event name from a specific contract for a specified time range.

Preparation for in flight tickets that also query events from different contracts
* https://linear.app/valora/issue/ENG-175/tvl-calculation-for-somm
* https://linear.app/valora/issue/ENG-176/transaction-volume-for-aerodrome

