### PR TITLE
feat(somm): mean tvl for somm

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,14 @@ Fetch referrals for a specific protocol, removes duplicate events across chains,
 yarn ts-node ./scripts/fetch-referrals.ts --protocol Beefy --output output.csv
 ```
 
+### Calculate Revenue
+
+Calculates revenue for a list of users on a specific protocol between startTimestamp and endTimestamp
+
+```bash
+yarn ts-node ./scripts.calculateRevenue.ts --protocolId Beefy --inputAddresses addresses.csv --outputFile output.csv --startTimestamp 1739311922 --endTimestamp 1741731122
+```
+
 ### Referrer User Count
 
 Fetch the count of users referred for a specific protocol. If no network IDs or referrer IDs are passed, get the user count for all referrers across all supported networks for that protocol.

--- a/scripts/calculateRevenue/protocols/index.ts
+++ b/scripts/calculateRevenue/protocols/index.ts
@@ -1,8 +1,10 @@
 import { Protocol, CalculateRevenueFn } from '../../types'
 import { calculateRevenue as calculateRevenueBeefy } from './beefy'
+import { calculateRevenue as calculateRevenueSomm } from './somm'
 
 const calculateRevenueHandlers: Record<Protocol, CalculateRevenueFn> = {
   Beefy: calculateRevenueBeefy,
+  Somm: calculateRevenueSomm,
 }
 
 export default calculateRevenueHandlers

--- a/scripts/calculateRevenue/protocols/somm/getEvents.test.ts
+++ b/scripts/calculateRevenue/protocols/somm/getEvents.test.ts
@@ -1,0 +1,83 @@
+import { fetchEvents } from '../utils/events'
+import { getEvents } from './getEvents'
+import { getViemPublicClient } from '../../../utils'
+import { NetworkId } from '../../../types'
+
+jest.mock('../utils/events')
+jest.mock('../../../utils')
+jest.mock('viem', () => ({
+  ...jest.requireActual('viem'),
+  getContract: jest.fn().mockReturnValue({
+    read: {
+      decimals: jest.fn().mockReturnValue(1),
+    },
+  }),
+}))
+
+const mockAddress1 = '0x1234567890123456789012345678901234567890'
+const mockAddress2 = '0x4567890123456789012345678901234567890123'
+
+describe('getEvents', () => {
+  it('should return the correct deposit and withdraw events', async () => {
+    const mockGetBlock = jest
+      .fn()
+      .mockImplementation(({ blockNumber }: { blockNumber: bigint }) => {
+        return {
+          timestamp: blockNumber * 100n,
+        }
+      })
+
+    jest.mocked(getViemPublicClient).mockReturnValue({
+      getBlock: mockGetBlock,
+    } as unknown as ReturnType<typeof getViemPublicClient>)
+    jest.mocked(fetchEvents).mockResolvedValueOnce([
+      {
+        args: { shares: 100n, sender: mockAddress1 },
+        blockNumber: BigInt(1),
+      },
+      {
+        args: { shares: 200n, sender: mockAddress2 },
+        blockNumber: BigInt(2),
+      },
+    ] as unknown as ReturnType<typeof fetchEvents>)
+    jest.mocked(fetchEvents).mockResolvedValueOnce([
+      {
+        args: { shares: 50n, sender: mockAddress1 },
+        blockNumber: BigInt(3),
+      },
+      {
+        args: { shares: 30n, sender: mockAddress2 },
+        blockNumber: BigInt(4),
+      },
+    ] as unknown as ReturnType<typeof fetchEvents>)
+    const result = await getEvents({
+      address: mockAddress1,
+      vaultInfo: {
+        networkId: NetworkId['arbitrum-one'],
+        vaultAddress: '0x1234567890123456789012345678901234567890',
+      },
+      startTimestamp: new Date('2021-01-01'),
+      endTimestamp: new Date('2021-01-10'),
+    })
+    expect(result).toEqual([
+      { amount: -5, timestamp: new Date(3 * 100 * 1000) },
+      { amount: 10, timestamp: new Date(1 * 100 * 1000) },
+    ])
+    expect(fetchEvents).toHaveBeenCalledTimes(2)
+    expect(fetchEvents).toHaveBeenNthCalledWith(1, {
+      contract: expect.any(Object),
+      networkId: NetworkId['arbitrum-one'],
+      eventName: 'Deposit',
+      startTimestamp: new Date('2021-01-01'),
+      endTimestamp: new Date('2021-01-10'),
+    })
+    expect(fetchEvents).toHaveBeenNthCalledWith(2, {
+      contract: expect.any(Object),
+      networkId: NetworkId['arbitrum-one'],
+      eventName: 'Withdraw',
+      startTimestamp: new Date('2021-01-01'),
+      endTimestamp: new Date('2021-01-10'),
+    })
+    expect(mockGetBlock).toHaveBeenCalledTimes(2)
+  })
+})

--- a/scripts/calculateRevenue/protocols/somm/getEvents.ts
+++ b/scripts/calculateRevenue/protocols/somm/getEvents.ts
@@ -1,0 +1,93 @@
+import {
+  Address,
+  erc20Abi,
+  erc4626Abi,
+  formatUnits,
+  getContract,
+  isAddressEqual,
+} from 'viem'
+import { getViemPublicClient } from '../../../utils'
+import { fetchEvents } from '../utils/events'
+import { TvlEvent, VaultInfo } from './types'
+
+/**
+ * Fetches and returns a list of TVL (Total Value Locked) change events for a given address and vault within a specified time range.
+ * The events include both deposits and withdrawals, and are sorted in reverse chronological order.
+ */
+export async function getEvents({
+  address,
+  vaultInfo,
+  startTimestamp,
+  endTimestamp,
+}: {
+  address: Address
+  vaultInfo: VaultInfo
+  startTimestamp: Date
+  endTimestamp: Date
+}) {
+  const client = getViemPublicClient(vaultInfo.networkId)
+  const vaultContract = getContract({
+    address: vaultInfo.vaultAddress,
+    abi: [...erc4626Abi, ...erc20Abi],
+    client,
+  })
+  const tvlEvents: TvlEvent[] = []
+
+  const decimals = await vaultContract.read.decimals()
+
+  const depositEvents = (
+    await fetchEvents({
+      contract: vaultContract,
+      networkId: vaultInfo.networkId,
+      eventName: 'Deposit',
+      startTimestamp,
+      endTimestamp,
+    })
+  ).filter((event) => {
+    return isAddressEqual((event.args as { sender: Address }).sender, address)
+  })
+
+  for (const depositEvent of depositEvents) {
+    const block = await client.getBlock({
+      blockNumber: depositEvent.blockNumber,
+    })
+    tvlEvents.push({
+      amount: Number(
+        formatUnits((depositEvent.args as { shares: bigint }).shares, decimals),
+      ),
+      timestamp: new Date(Number(block.timestamp * 1000n)),
+    })
+  }
+
+  const withdrawEvents = (
+    await fetchEvents({
+      contract: vaultContract,
+      networkId: vaultInfo.networkId,
+      eventName: 'Withdraw',
+      startTimestamp,
+      endTimestamp,
+    })
+  ).filter((event) => {
+    return isAddressEqual((event.args as { sender: Address }).sender, address)
+  })
+
+  for (const withdrawEvent of withdrawEvents) {
+    const block = await client.getBlock({
+      blockNumber: withdrawEvent.blockNumber,
+    })
+    tvlEvents.push({
+      amount:
+        -1 *
+        Number(
+          formatUnits(
+            (withdrawEvent.args as { shares: bigint }).shares,
+            decimals,
+          ),
+        ),
+      timestamp: new Date(Number(block.timestamp * 1000n)),
+    })
+  }
+
+  // Sort events in reverse chronological order
+  return tvlEvents.sort((a, b) => b.timestamp.getTime() - a.timestamp.getTime())
+}

--- a/scripts/calculateRevenue/protocols/somm/getVaults.ts
+++ b/scripts/calculateRevenue/protocols/somm/getVaults.ts
@@ -1,0 +1,13 @@
+import { NetworkId } from '../../../types'
+import { VaultInfo } from './types'
+
+// TODO(ENG-202): Dynamically fetch vaults from the Somm API
+export function getVaults(): VaultInfo[] {
+  return [
+    // Real Yield ETH on Arbitrum
+    {
+      networkId: NetworkId['arbitrum-one'],
+      vaultAddress: '0xc47bb288178ea40bf520a91826a3dee9e0dbfa4c',
+    },
+  ]
+}

--- a/scripts/calculateRevenue/protocols/somm/index.test.ts
+++ b/scripts/calculateRevenue/protocols/somm/index.test.ts
@@ -1,0 +1,62 @@
+import { Address } from 'viem'
+import { NetworkId } from '../../../types'
+import { getDailyMeanTvl } from './index'
+import { getEvents } from './getEvents'
+
+jest.mock('viem', () => ({
+  ...jest.requireActual('viem'),
+  getContract: jest.fn().mockReturnValue({
+    read: {
+      balanceOf: jest.fn().mockReturnValue(BigInt(100 * 1e18)),
+      decimals: jest.fn().mockReturnValue(18),
+    },
+  }),
+}))
+
+jest.mock('./getEvents')
+
+const vaultInfo = {
+  networkId: NetworkId['arbitrum-one'],
+  vaultAddress: '0x1234567890123456789012345678901234567890' as Address,
+}
+const address = '0x1234567890123456789012345678901234567890'
+
+describe('getDailyMeanTvl', () => {
+  it('should throw an error if endTimestamp is in the future', async () => {
+    const startTimestamp = new Date('2021-01-0')
+    const endTimestamp = new Date('2022-01-01')
+    const nowTimestamp = new Date('2021-01-01')
+    await expect(
+      getDailyMeanTvl({
+        vaultInfo,
+        address,
+        startTimestamp,
+        endTimestamp,
+        nowTimestamp,
+      }),
+    ).rejects.toThrow('Cannot have an endTimestamp in the future')
+  })
+  it('should return the correct daily mean TVL', async () => {
+    const startTimestamp = new Date('2021-01-05')
+    const endTimestamp = new Date('2021-01-20')
+    const nowTimestamp = new Date('2021-01-30')
+    jest.mocked(getEvents).mockResolvedValueOnce([
+      { amount: 50, timestamp: new Date('2021-01-25') }, // a 50 LP token deposit
+      { amount: -30, timestamp: new Date('2021-01-15') }, // a 30 LP token withdrawal
+      { amount: 20, timestamp: new Date('2021-01-10') }, // a 20 LP token deposit
+    ])
+    const result = await getDailyMeanTvl({
+      vaultInfo,
+      address,
+      startTimestamp,
+      endTimestamp,
+      nowTimestamp,
+    })
+    // first chuck of time is 5 days with 100 TVL, the current balance. All outside of the range so it isn't counted
+    // second chunk of time is 10 days with 50 TVL, only 5 days are in the range so 50 * 5 = 250 TVL days
+    // third chunk of time is 5 days with 80 TVL, all 5 days are in the range so 80 * 5 = 400 TVL days
+    // fourth chunk of time is 10 days with 60 TVL, only 5 days are in the range so 60 * 5 = 300 TVL days
+    // mean TVL = (250 + 400 + 300) / 15 = 63.33333333333333
+    expect(result).toBeCloseTo(63.33333333333333)
+  })
+})

--- a/scripts/calculateRevenue/protocols/somm/index.ts
+++ b/scripts/calculateRevenue/protocols/somm/index.ts
@@ -1,0 +1,123 @@
+import { Address, erc20Abi, formatUnits, getContract, isAddress } from 'viem'
+import { getViemPublicClient } from '../../../utils'
+import { getVaults } from './getVaults'
+import { VaultInfo } from './types'
+import { getEvents } from './getEvents'
+
+const ONE_DAY = 24 * 60 * 60 * 1000
+
+export async function getBalanceOfAddress({
+  vaultInfo,
+  address,
+}: {
+  vaultInfo: VaultInfo
+  address: Address
+}) {
+  const client = getViemPublicClient(vaultInfo.networkId)
+  const vaultContract = getContract({
+    address: vaultInfo.vaultAddress,
+    abi: erc20Abi,
+    client,
+  })
+  return vaultContract.read.balanceOf([address])
+}
+
+/**
+ * Calculates the daily mean Total Value Locked (TVL) for a given user address
+ * and vault pair within a specified time range.
+ *
+ * TODO(ENG-201): Return TVL in USD
+ */
+export async function getDailyMeanTvl({
+  vaultInfo,
+  address,
+  startTimestamp,
+  endTimestamp,
+  nowTimestamp,
+}: {
+  vaultInfo: VaultInfo
+  address: Address
+  startTimestamp: Date
+  endTimestamp: Date
+  nowTimestamp: Date
+}) {
+  if (endTimestamp.getTime() > nowTimestamp.getTime()) {
+    throw new Error('Cannot have an endTimestamp in the future')
+  }
+  const client = getViemPublicClient(vaultInfo.networkId)
+  const vaultContract = getContract({
+    address: vaultInfo.vaultAddress,
+    abi: erc20Abi,
+    client,
+  })
+  const currentLPTokenBalance = await vaultContract.read.balanceOf([address])
+  const tokenDecimals = await vaultContract.read.decimals()
+
+  const tvlEvents = await getEvents({
+    address,
+    vaultInfo,
+    startTimestamp,
+    endTimestamp: nowTimestamp,
+  })
+
+  let prevTimestamp = nowTimestamp
+  let tvlDays = 0
+  let currentTvl = Number(formatUnits(currentLPTokenBalance, tokenDecimals))
+
+  // Loop through the TVL events in reverse chronological order keeping track of the user's TVL as
+  // different TVL events occur (withdaws and deposits) and adding up the total TVL days within the start and end timestamps
+  for (const tvlEvent of tvlEvents) {
+    // the default case is that the previous event and current event are outside of the time range
+    let daysInRange = 0
+
+    // if the previous event is outside of the time range and the current event is inside the time range
+    if (
+      prevTimestamp.getTime() >= endTimestamp.getTime() &&
+      tvlEvent.timestamp.getTime() < endTimestamp.getTime()
+    ) {
+      daysInRange = getDaysInRange(tvlEvent.timestamp, endTimestamp)
+    }
+    // else the events are both inside the time range
+    else if (tvlEvent.timestamp.getTime() < endTimestamp.getTime()) {
+      daysInRange = getDaysInRange(tvlEvent.timestamp, prevTimestamp)
+    }
+    tvlDays += daysInRange * currentTvl
+    currentTvl -= tvlEvent.amount
+    prevTimestamp = tvlEvent.timestamp
+  }
+  tvlDays += getDaysInRange(startTimestamp, prevTimestamp) * currentTvl
+  return tvlDays / getDaysInRange(startTimestamp, endTimestamp)
+}
+
+function getDaysInRange(startTimestamp: Date, endTimestamp: Date) {
+  return (endTimestamp.getTime() - startTimestamp.getTime()) / ONE_DAY
+}
+
+export async function calculateRevenue({
+  address,
+  startTimestamp,
+  endTimestamp,
+}: {
+  address: string
+  startTimestamp: Date
+  endTimestamp: Date
+}): Promise<number> {
+  if (!isAddress(address)) {
+    throw new Error('Invalid address')
+  }
+  const vaultsInfo = getVaults()
+
+  let totalRevenue = 0
+  const nowTimestamp = new Date()
+  for (const vaultInfo of vaultsInfo) {
+    const vaultRevenue = await getDailyMeanTvl({
+      vaultInfo,
+      address,
+      startTimestamp,
+      endTimestamp,
+      nowTimestamp,
+    })
+    totalRevenue += vaultRevenue
+  }
+  return totalRevenue
+}

--- a/scripts/calculateRevenue/protocols/somm/types.ts
+++ b/scripts/calculateRevenue/protocols/somm/types.ts
@@ -1,0 +1,12 @@
+import { Address } from 'viem'
+import { NetworkId } from '../../../types'
+
+export interface VaultInfo {
+  networkId: NetworkId
+  vaultAddress: Address
+}
+
+export interface TvlEvent {
+  amount: number
+  timestamp: Date
+}

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -28,6 +28,7 @@ async function getConfig() {
     .option('shell', {
       description: 'Print shell commands for deployed conracts to stdout',
       type: 'boolean',
+      conflicts: ['use-defender'],
     })
     .option('owner-address', {
       description: 'Address of the address to use as owner',
@@ -59,8 +60,6 @@ const SUPPORTED_NETWORKS = [
   'polygon',
   'op',
   'base',
-  'berachain',
-  'vana',
 ]
 
 const ONE_DAY = 60 * 60 * 24

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -28,7 +28,6 @@ async function getConfig() {
     .option('shell', {
       description: 'Print shell commands for deployed conracts to stdout',
       type: 'boolean',
-      conflicts: ['use-defender'],
     })
     .option('owner-address', {
       description: 'Address of the address to use as owner',
@@ -60,6 +59,8 @@ const SUPPORTED_NETWORKS = [
   'polygon',
   'op',
   'base',
+  'berachain',
+  'vana',
 ]
 
 const ONE_DAY = 60 * 60 * 24

--- a/scripts/protocolFilters/index.ts
+++ b/scripts/protocolFilters/index.ts
@@ -1,6 +1,8 @@
 import { FilterFunction, Protocol } from '../types'
 import { filterEvents as filterBeefyEvents } from './beefy'
+import { filterEvents as filterSommEvents } from './somm'
 
 export const protocolFilters: Record<Protocol, FilterFunction> = {
   Beefy: filterBeefyEvents,
+  Somm: filterSommEvents,
 }

--- a/scripts/protocolFilters/somm.ts
+++ b/scripts/protocolFilters/somm.ts
@@ -1,0 +1,18 @@
+import { ReferralEvent } from '../types'
+
+export async function filterEvents(
+  events: ReferralEvent[],
+): Promise<ReferralEvent[]> {
+  const filteredEvents = []
+  for (const event of events) {
+    if (await filter(event)) {
+      filteredEvents.push(event)
+    }
+  }
+  return filteredEvents
+}
+
+// TODO(ENG-200): Implement the filter function
+export async function filter(event: ReferralEvent): Promise<boolean> {
+  return !!event
+}

--- a/scripts/types.ts
+++ b/scripts/types.ts
@@ -1,4 +1,4 @@
-export const protocols = ['Beefy'] as const
+export const protocols = ['Beefy', 'Somm'] as const
 export type Protocol = (typeof protocols)[number]
 export type FilterFunction = (
   events: ReferralEvent[],


### PR DESCRIPTION
Calculates mean TVL by finding the users current LP token tvl, all tvl changing events (deposits and withdraws), and working backwards to determine the user's TVL over time.

TODO's in other tickets: 
* returning the daily mean tvl in usd instead of the mean tvl in LP token
* adding more vaults
* adding a filter function to filter out users that were using somm before the divvi event.

https://linear.app/valora/issue/ENG-175/tvl-calculation-for-somm