### PR TITLE
refactor(getBlock): make client.getBlock a memoized function

### DIFF
--- a/scripts/calculateRevenue/protocols/beefy/helpers.test.ts
+++ b/scripts/calculateRevenue/protocols/beefy/helpers.test.ts
@@ -1,7 +1,7 @@
 import { _fetchVaultTvlHistory, _fetchFeeEvents } from './helpers'
 import { BeefyVaultTvlData } from './types'
 import { getStrategyContract } from '../utils/viem'
-import { getViemPublicClient } from '../../../utils'
+import { getBlock } from '../../../utils'
 import { NetworkId } from '../../../types'
 import nock from 'nock'
 import { fetchEvents } from '../utils/events'
@@ -117,17 +117,13 @@ describe('Beefy revenue calculation helpers', () => {
         { blockNumber: 0n, args: { beefyFees: 100n } },
         { blockNumber: 10001n, args: { beefyFees: 200n } },
       ] as unknown as ReturnType<typeof fetchEvents>)
-      const mockGetBlock = jest
-        .fn()
-        .mockImplementation(({ blockNumber }: { blockNumber: bigint }) => {
-          return {
+      jest.mocked(getBlock).mockImplementation(
+        (_networkId: NetworkId, blockNumber: bigint) =>
+          Promise.resolve({
             timestamp: blockNumber * 100n,
-          }
-        })
+          }) as unknown as ReturnType<typeof getBlock>,
+      )
 
-      jest.mocked(getViemPublicClient).mockReturnValue({
-        getBlock: mockGetBlock,
-      } as unknown as ReturnType<typeof getViemPublicClient>)
       jest.mocked(getStrategyContract).mockResolvedValueOnce({
         abi: erc20Abi,
         address: '0x123',

--- a/scripts/calculateRevenue/protocols/beefy/helpers.ts
+++ b/scripts/calculateRevenue/protocols/beefy/helpers.ts
@@ -1,7 +1,7 @@
 import { NetworkId } from '../../../types'
 import { fetchWithTimeout } from '../../../utils/fetchWithTimeout'
 import { getStrategyContract } from '../utils/viem'
-import { getViemPublicClient } from '../../../utils'
+import { getBlock } from '../../../utils'
 import { Address } from 'viem'
 import { FeeEvent, BeefyVaultTvlData } from './types'
 import memoize from '@github/memoize'
@@ -36,12 +36,9 @@ export async function _fetchFeeEvents({
   })
 
   const feeEvents: FeeEvent[] = []
-  const client = getViemPublicClient(networkId)
 
   for (const feeLog of feeLogEvents) {
-    const block = await client.getBlock({
-      blockNumber: feeLog.blockNumber,
-    })
+    const block = await getBlock(networkId, feeLog.blockNumber)
     feeEvents.push({
       beefyFee: (feeLog.args as { beefyFees: number }).beefyFees ?? 0,
       timestamp: new Date(Number(block.timestamp * 1000n)),

--- a/scripts/calculateRevenue/protocols/somm/getEvents.test.ts
+++ b/scripts/calculateRevenue/protocols/somm/getEvents.test.ts
@@ -1,6 +1,6 @@
 import { fetchEvents } from '../utils/events'
 import { getEvents } from './getEvents'
-import { getViemPublicClient } from '../../../utils'
+import { getBlock } from '../../../utils'
 import { NetworkId } from '../../../types'
 
 jest.mock('../utils/events')
@@ -19,17 +19,13 @@ const mockAddress2 = '0x4567890123456789012345678901234567890123'
 
 describe('getEvents', () => {
   it('should return the correct deposit and withdraw events', async () => {
-    const mockGetBlock = jest
-      .fn()
-      .mockImplementation(({ blockNumber }: { blockNumber: bigint }) => {
-        return {
+    jest.mocked(getBlock).mockImplementation(
+      (_networkId: NetworkId, blockNumber: bigint) =>
+        Promise.resolve({
           timestamp: blockNumber * 100n,
-        }
-      })
+        }) as unknown as ReturnType<typeof getBlock>,
+    )
 
-    jest.mocked(getViemPublicClient).mockReturnValue({
-      getBlock: mockGetBlock,
-    } as unknown as ReturnType<typeof getViemPublicClient>)
     jest.mocked(fetchEvents).mockResolvedValueOnce([
       {
         args: { shares: 100n, sender: mockAddress1 },
@@ -78,6 +74,6 @@ describe('getEvents', () => {
       startTimestamp: new Date('2021-01-01'),
       endTimestamp: new Date('2021-01-10'),
     })
-    expect(mockGetBlock).toHaveBeenCalledTimes(2)
+    expect(getBlock).toHaveBeenCalledTimes(2)
   })
 })

--- a/scripts/calculateRevenue/protocols/somm/getEvents.ts
+++ b/scripts/calculateRevenue/protocols/somm/getEvents.ts
@@ -6,7 +6,7 @@ import {
   getContract,
   isAddressEqual,
 } from 'viem'
-import { getViemPublicClient } from '../../../utils'
+import { getBlock, getViemPublicClient } from '../../../utils'
 import { fetchEvents } from '../utils/events'
 import { TvlEvent, VaultInfo } from './types'
 
@@ -48,9 +48,7 @@ export async function getEvents({
   })
 
   for (const depositEvent of depositEvents) {
-    const block = await client.getBlock({
-      blockNumber: depositEvent.blockNumber,
-    })
+    const block = await getBlock(vaultInfo.networkId, depositEvent.blockNumber)
     tvlEvents.push({
       amount: Number(
         formatUnits((depositEvent.args as { shares: bigint }).shares, decimals),
@@ -72,9 +70,7 @@ export async function getEvents({
   })
 
   for (const withdrawEvent of withdrawEvents) {
-    const block = await client.getBlock({
-      blockNumber: withdrawEvent.blockNumber,
-    })
+    const block = await getBlock(vaultInfo.networkId, withdrawEvent.blockNumber)
     tvlEvents.push({
       amount:
         -1 *

--- a/scripts/utils/index.ts
+++ b/scripts/utils/index.ts
@@ -9,6 +9,7 @@ import {
   Address,
   PublicClient,
 } from 'viem'
+import memoize from '@github/memoize'
 
 const NETWORK_ID_TO_VIEM_CLIENT = {
   [NetworkId['ethereum-mainnet']]: createPublicClient({
@@ -47,6 +48,16 @@ export function getViemPublicClient(networkId: NetworkId) {
   }
   return client
 }
+
+function _getBlock(networkId: NetworkId, blockNumber: bigint) {
+  return getViemPublicClient(networkId).getBlock({
+    blockNumber,
+  })
+}
+
+export const getBlock = memoize(_getBlock, {
+  hash: (...params: Parameters<typeof _getBlock>) => params.join(','),
+})
 
 /**
  * Returns a contract object representing the registry


### PR DESCRIPTION
Should help save a few network calls while running the script.

also based on pr feedback: https://github.com/divvi-xyz/divvi-protocol-v0/pull/44#discussion_r1988115519