### PR TITLE
fix: fix deployment with owner other than deployer

### DIFF
--- a/contracts/RewardPool.sol
+++ b/contracts/RewardPool.sol
@@ -103,7 +103,7 @@ contract RewardPool is
     __UUPSUpgradeable_init();
     __ReentrancyGuard_init();
 
-    grantRole(MANAGER_ROLE, _manager);
+    _grantRole(MANAGER_ROLE, _manager);
 
     poolToken = _poolToken;
     isNativeToken = (_poolToken == NATIVE_TOKEN_ADDRESS);


### PR DESCRIPTION
### Description

The Reward pool contract is unable to deploy with the Owner other than the deployer.

The problem is with granting Manager role during initialization. After the owner is set, the checks in `grantRole()` prevent deployer from granting the Manager role. This is inconvenient since we want to set both Owner and Manger during contract initialization.

This PR fixes it by replacing the `grantRole()` call during initialization with an internal `_grantRole()` to bypass role checks.

The tests, sadly, didn't cover the case to surface earlier. 

### Test plan

* Updated unit tests

### Related issues

Related to RET-204