### PR TITLE
chore: use contract:action naming convention in tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,13 +39,13 @@ yarn hardhat --network localhost registry:populate
 Deploy mock token:
 
 ```bash
-yarn hardhat deploy:mock-token --network localhost
+yarn hardhat mock-token:deploy --network localhost
 ```
 
 Deploy RewardPool using the deployed mock token address:
 
 ```bash
-yarn hardhat deploy:reward-pool \
+yarn hardhat reward-pool:deploy \
     --network localhost \
     --pool-token 0x5FbDB2315678afecb367f032d93F642f64180aa3 \
     --reward-function 0xa1b2c3d4e5f67890abcdef1234567890abcdef12 \
@@ -134,7 +134,7 @@ yarn hardhat registry:deploy --network celo
 To deploy RewardPool, run:
 
 ```bash
-yarn hardhat deploy:reward-pool \
+yarn hardhat reward-pool:deploy \
     --network celo \
     --use-defender \
     --defender-deploy-salt <SALT> \

--- a/tasks/mockToken.ts
+++ b/tasks/mockToken.ts
@@ -1,7 +1,7 @@
 import { task } from 'hardhat/config'
 import { deployContract } from './helpers/deployHelpers'
 
-task('deploy:mock-token', 'Deploy mock ERC-20 token').setAction(
+task('mock-token:deploy', 'Deploy mock ERC-20 token').setAction(
   async (_, hre) => {
     await deployContract(hre, 'MockERC20', ['Mock ERC20', 'MOCK'])
   },

--- a/tasks/rewardPool.ts
+++ b/tasks/rewardPool.ts
@@ -6,7 +6,7 @@ import {
   ONE_DAY,
 } from './helpers/deployHelpers'
 
-task('deploy:reward-pool', 'Deploy RewardPool contract')
+task('reward-pool:deploy', 'Deploy RewardPool contract')
   .addParam('poolToken', 'Address of the token used for rewards')
   .addOptionalParam('managerAddress', 'Address that will have MANAGER_ROLE')
   .addOptionalParam('rewardFunction', 'Identifier of the reward function')
@@ -64,7 +64,7 @@ task('deploy:reward-pool', 'Deploy RewardPool contract')
     )
   })
 
-task('upgrade:reward-pool', 'Upgrade RewardPool contract')
+task('reward-pool:upgrade', 'Upgrade RewardPool contract')
   .addParam('proxyAddress', 'Address of the token used for rewards')
   .addFlag('useDefender', 'Deploy using OpenZeppelin Defender')
   .addOptionalParam('defenderDeploySalt', 'Salt to use for CREATE2 deployments')


### PR DESCRIPTION
Use the `contract:action` naming convention for all tasks, similar to the one implemented for the Registry task. 

It seems natural to put the contract name first, as we group tasks per contract, and different contracts may have different associated tasks.

This makes this naming approach consistent.

Resulting tasks:
* `registry:deploy`
* `registry:populate`
* `reward-pool:deploy`
* `reward-pool:upgrade`
* `mock-token:deploy`