### PR TITLE
fix: populateRegistry failing with array index out of bounds

### DIFF
--- a/tasks/helpers/populateRegistry.ts
+++ b/tasks/helpers/populateRegistry.ts
@@ -9,7 +9,11 @@ interface ReferrerConfig {
 const REFERRERS: Record<string, ReferrerConfig> = {
   leefy: {
     protocolIds: ['dompounder', 'zoot', 'bartender'],
-    rewardRates: [BigInt('1000000000000000000'), BigInt('1000000000000000000'), BigInt('1000000000000000000')],
+    rewardRates: [
+      BigInt('1000000000000000000'),
+      BigInt('1000000000000000000'),
+      BigInt('1000000000000000000'),
+    ],
   },
   marianashot: {
     protocolIds: ['memenfts', 'zoot'],

--- a/tasks/helpers/populateRegistry.ts
+++ b/tasks/helpers/populateRegistry.ts
@@ -9,7 +9,7 @@ interface ReferrerConfig {
 const REFERRERS: Record<string, ReferrerConfig> = {
   leefy: {
     protocolIds: ['dompounder', 'zoot', 'bartender'],
-    rewardRates: [BigInt('1000000000000000000'), BigInt('1000000000000000000')],
+    rewardRates: [BigInt('1000000000000000000'), BigInt('1000000000000000000'), BigInt('1000000000000000000')],
   },
   marianashot: {
     protocolIds: ['memenfts', 'zoot'],


### PR DESCRIPTION
There were 3 protocolIds for `leefy` but only 2 rewardRates, added a third one and running `yarn hardhat --network localhost registry:populate` worked.