### PR TITLE
feat(testing): Add in reward calculation script for e2e testing

### DIFF
--- a/.openzeppelin/celo.json
+++ b/.openzeppelin/celo.json
@@ -6,6 +6,11 @@
       "txHash": "0x0436592e0956f71ebc7c92ff5b3c4ada994c42c72fe7b548968a01ed059c6244",
       "remoteDeploymentId": "86263ee1-5d9e-4c81-8096-a5c24099628c",
       "kind": "uups"
+    },
+    {
+      "address": "0x5782CaB7e3dC7991d15665A413aa64a52E62B769",
+      "txHash": "0x3b86fdcbbf8fd5860eaf4f0d34ac10a833343268699f7122ec3d1733caed544c",
+      "kind": "uups"
     }
   ],
   "impls": {

--- a/scripts/calculateRevenue/protocols/utils/events.ts
+++ b/scripts/calculateRevenue/protocols/utils/events.ts
@@ -37,7 +37,6 @@ export async function _getNearestBlock(
     `${DEFI_LLAMA_API_URL}/block/${defiLlamaChain}/${unixTimestamp}`,
   )
   if (!response.ok) {
-    console.log(response)
     throw new Error(
       `Error while fetching block timestamp from DefiLlama: ${response}`,
     )

--- a/scripts/calculateRevenue/protocols/utils/events.ts
+++ b/scripts/calculateRevenue/protocols/utils/events.ts
@@ -37,6 +37,7 @@ export async function _getNearestBlock(
     `${DEFI_LLAMA_API_URL}/block/${defiLlamaChain}/${unixTimestamp}`,
   )
   if (!response.ok) {
+    console.log(response)
     throw new Error(
       `Error while fetching block timestamp from DefiLlama: ${response}`,
     )

--- a/scripts/calculateRewards/e2eTestRewards.ts
+++ b/scripts/calculateRewards/e2eTestRewards.ts
@@ -1,0 +1,98 @@
+import yargs from 'yargs'
+import { parse } from 'csv-parse/sync'
+import { readFileSync } from 'fs'
+import { createAddRewardSafeTransactionJSON } from '../utils/createSafeTransactionsBatch'
+
+// e2e Testing RewardPool address
+const REWARD_POOL_ADDRESS = '0x5782CaB7e3dC7991d15665A413aa64a52E62B769' // on Celo mainnet
+
+export function calculateTestRewards({ kpiData }: { kpiData: KpiRow[] }) {
+  const referrerKpis = kpiData.reduce(
+    (acc, row) => {
+      if (!(row.referrerId in acc)) {
+        acc[row.referrerId] = BigInt(row.revenue)
+      } else {
+        acc[row.referrerId] += BigInt(row.revenue)
+      }
+      return acc
+    },
+    {} as Record<string, bigint>,
+  )
+
+  const rewards = Object.entries(referrerKpis).map(([referrerId, kpi]) => {
+    return {
+      referrerId,
+      kpi,
+      rewardAmount: kpi.toString(),
+    }
+  })
+  return rewards
+}
+
+function parseArgs() {
+  return yargs
+    .option('input-file', {
+      alias: 'i',
+      description: 'input file path containing transaction data',
+      type: 'string',
+      demandOption: false,
+    })
+    .option('output-file', {
+      alias: 'o',
+      description: 'output file path to write reward allocations',
+      type: 'string',
+      demandOption: false,
+    })
+    .option('start-timestamp', {
+      alias: 's',
+      description: 'start timestamp',
+      type: 'string',
+      demandOption: true,
+    })
+    .option('end-timestamp', {
+      alias: 'e',
+      description: 'end timestamp',
+      type: 'string',
+      demandOption: true,
+    })
+    .strict()
+    .parseSync()
+}
+
+interface KpiRow {
+  referrerId: string
+  userAddress: string
+  revenue: string
+}
+
+async function main(args: ReturnType<typeof parseArgs>) {
+  const inputPath = args['input-file'] ?? 'celo-transactions.csv'
+  const outputPath =
+    args['output-file'] ?? 'celo-transactions-safe-transactions.json'
+
+  const kpiData = parse(readFileSync(inputPath, 'utf-8').toString(), {
+    skip_empty_lines: true,
+    delimiter: ',',
+    columns: true,
+  }) as KpiRow[]
+
+  const rewards = calculateTestRewards({
+    kpiData,
+  })
+
+  createAddRewardSafeTransactionJSON({
+    filePath: outputPath,
+    rewardPoolAddress: REWARD_POOL_ADDRESS,
+    rewards,
+    startTimestamp: args['start-timestamp'],
+    endTimestamp: args['end-timestamp'],
+  })
+}
+
+// Only run main if this file is being executed directly
+if (require.main === module) {
+  main(parseArgs()).catch((error) => {
+    console.error(error)
+    process.exit(1)
+  })
+}


### PR DESCRIPTION
For [ENG-334](https://linear.app/valora/issue/ENG-334/setup-rewards-entity-for-e2e-testing).

Adds in a script for calculating rewards for the e2e test campaign according to [this doc](https://docs.google.com/document/d/1xVe0DgNJ39KbBlyBrKmqsuhHnLCMYOJ0J9OzOpM93rU/edit?tab=t.0).

The e2e Reward Pool is deployed on Celo [here](https://celoscan.io/address/0x5782CaB7e3dC7991d15665A413aa64a52E62B769).
The e2e Campaign Provider Safe is [here](https://app.safe.global/home?safe=oeth:0xDe9D9522241baB65D432B3aEbee29e378de5856E).
The e2e Builder Safe is [here](https://app.safe.global/home?safe=oeth:0xfC6Eb1Fb78350809591180bf5566915A32f5a515).
The Reward Pool has been loaded with 1B [MockToken](https://celoscan.io/address/0x91652b5c6a30e813262b31868885B5BFEB134354).

Since we don't have a script yet for registering referrals against the campaign entity (part of [ENG-333](https://linear.app/valora/issue/ENG-333/sample-app-for-testing)), you can test out the full e2e flow by creating a file `test-users.csv` with the following contents:

```
referrerId,userAddress,timestamp
0xfC6Eb1Fb78350809591180bf5566915A32f5a515,0x9e8911F22e6Db6d5Cc776e62882058eC9E003d7c,1747083817
```

Then, you can re-use the `celo-transactions` revenue calculation to count transactions KPIs:

```bash
yarn ts-node ./scripts/calculateRevenue.ts --input-file test-users.csv --output-file test-transactions.csv --protocol celo-transactions --start-timestamp 1746147817000 --end-timestamp 1747083899000   
```

This should return 4 transactions for the user in that time range. Then, you can run against the new reward calculation script to generate the JSON batch transactions that should be uploaded to the Safe UI:

```bash
yarn ts-node ./scripts/calculateRewards/e2eTestRewards.ts --input-file test-transactions.csv --output-file test-rewards.json --start-timestamp 1746147817000 --end-timestamp 1747083899000
```

This generates a batch which rewards the builder entity with 1 MockToken from the Reward Pool per transaction made by referred users, so 4 MockToken in all. Performing a Tenderly simulation of the generated batch from the Campaign Provider Safe results in a successful simulation (I have not actually executed the batch however).