### PR TITLE
fix(scripts): introduce getBlockRange and standardize to [start,end) block ranges

### DIFF
--- a/scripts/calculateRevenue.ts
+++ b/scripts/calculateRevenue.ts
@@ -69,15 +69,15 @@ function parseArgs() {
     .option('start-timestamp', {
       alias: 's',
       description:
-        'timestamp at which to start checking for revenue (new Date() compatible)',
-      type: 'number',
+        'Start timestamp (inclusive) for revenue calculation (new Date() compatible epoch milliseconds or string)',
+      type: 'string',
       demandOption: true,
     })
     .option('end-timestamp', {
       alias: 'e',
       description:
-        'timestamp at which to stop checking for revenue (new Date() compatible)',
-      type: 'number',
+        'End timestamp (exclusive) for revenue calculation (new Date() compatible epoch milliseconds or string)',
+      type: 'string',
       demandOption: true,
     })
     .strict()

--- a/scripts/calculateRevenue/protocols/aave/blockchainData/reserveFactor.ts
+++ b/scripts/calculateRevenue/protocols/aave/blockchainData/reserveFactor.ts
@@ -17,18 +17,18 @@ export async function _getReserveFactorHistory({
   networkId,
   poolConfiguratorAddress,
   startBlock,
-  endBlock,
+  endBlockExclusive,
 }: {
   networkId: NetworkId
   poolConfiguratorAddress: Address
-  startBlock: number
-  endBlock: number
+  startBlock: number // inclusive
+  endBlockExclusive: number
 }): Promise<Map<Address, ReserveFactor[]>> {
   const client = getHyperSyncClient(networkId)
 
   const query = {
     fromBlock: startBlock,
-    toBlock: endBlock,
+    toBlock: endBlockExclusive,
     logs: [
       {
         address: [poolConfiguratorAddress],

--- a/scripts/calculateRevenue/protocols/aave/blockchainData/subgraph.ts
+++ b/scripts/calculateRevenue/protocols/aave/blockchainData/subgraph.ts
@@ -53,10 +53,7 @@ export async function getATokenScaledBalanceHistory({
           }
         }
         aTokenBalanceHistory(
-          where: {
-            timestamp_gte: $startTimestamp
-            timestamp_lte: $endTimestamp
-          }
+          where: { timestamp_gte: $startTimestamp, timestamp_lt: $endTimestamp }
           orderBy: timestamp
           orderDirection: asc
         ) {

--- a/scripts/calculateRevenue/protocols/arbitrum/index.ts
+++ b/scripts/calculateRevenue/protocols/arbitrum/index.ts
@@ -21,6 +21,6 @@ export async function calculateRevenue({
     networkId: NetworkId['arbitrum-one'],
     users: [address],
     startBlock,
-    endBlockExclusive: endBlockExclusive,
+    endBlockExclusive,
   })
 }

--- a/scripts/calculateRevenue/protocols/arbitrum/index.ts
+++ b/scripts/calculateRevenue/protocols/arbitrum/index.ts
@@ -1,5 +1,5 @@
 import { NetworkId } from '../../../types'
-import { getNearestBlock } from '../utils/events'
+import { getBlockRange } from '../utils/events'
 import { fetchTotalTransactionFees } from '../utils/networks'
 
 export async function calculateRevenue({
@@ -11,19 +11,16 @@ export async function calculateRevenue({
   startTimestamp: Date
   endTimestamp: Date
 }): Promise<number> {
-  const startBlock = await getNearestBlock(
-    NetworkId['arbitrum-one'],
+  const { startBlock, endBlockExclusive } = await getBlockRange({
+    networkId: NetworkId['arbitrum-one'],
     startTimestamp,
-  )
-  const endBlock = await getNearestBlock(
-    NetworkId['arbitrum-one'],
     endTimestamp,
-  )
+  })
 
   return await fetchTotalTransactionFees({
     networkId: NetworkId['arbitrum-one'],
     users: [address],
     startBlock,
-    endBlock,
+    endBlockExclusive: endBlockExclusive,
   })
 }

--- a/scripts/calculateRevenue/protocols/celo-pg/index.ts
+++ b/scripts/calculateRevenue/protocols/celo-pg/index.ts
@@ -1,5 +1,5 @@
 import { NetworkId } from '../../../types'
-import { getNearestBlock } from '../utils/events'
+import { getBlockRange } from '../utils/events'
 import { fetchTotalTransactionFees } from '../utils/networks'
 
 export async function calculateRevenue({
@@ -11,19 +11,16 @@ export async function calculateRevenue({
   startTimestamp: Date
   endTimestamp: Date
 }): Promise<number> {
-  const startBlock = await getNearestBlock(
-    NetworkId['celo-mainnet'],
+  const { startBlock, endBlockExclusive } = await getBlockRange({
+    networkId: NetworkId['celo-mainnet'],
     startTimestamp,
-  )
-  const endBlock = await getNearestBlock(
-    NetworkId['celo-mainnet'],
     endTimestamp,
-  )
+  })
 
   return await fetchTotalTransactionFees({
     networkId: NetworkId['celo-mainnet'],
     users: [address],
     startBlock,
-    endBlock,
+    endBlockExclusive,
   })
 }

--- a/scripts/calculateRevenue/protocols/celoTransactions/index.ts
+++ b/scripts/calculateRevenue/protocols/celoTransactions/index.ts
@@ -1,5 +1,5 @@
 import { NetworkId } from '../../../types'
-import { getNearestBlock } from '../utils/events'
+import { getBlockRange } from '../utils/events'
 import { fetchTotalTransactions } from '../utils/networks'
 
 export async function calculateRevenue({
@@ -11,19 +11,16 @@ export async function calculateRevenue({
   startTimestamp: Date
   endTimestamp: Date
 }): Promise<number> {
-  const startBlock = await getNearestBlock(
-    NetworkId['celo-mainnet'],
+  const { startBlock, endBlockExclusive } = await getBlockRange({
+    networkId: NetworkId['celo-mainnet'],
     startTimestamp,
-  )
-  const endBlock = await getNearestBlock(
-    NetworkId['celo-mainnet'],
     endTimestamp,
-  )
+  })
 
   return await fetchTotalTransactions({
     networkId: NetworkId['celo-mainnet'],
     users: [address],
     startBlock,
-    endBlock,
+    endBlockExclusive,
   })
 }

--- a/scripts/calculateRevenue/protocols/utils/events.test.ts
+++ b/scripts/calculateRevenue/protocols/utils/events.test.ts
@@ -18,6 +18,8 @@ jest.mock('@github/memoize', () => ({
 
 jest.mock('../../../utils')
 
+const networkId = NetworkId['arbitrum-one']
+
 describe('On-chain event helpers', () => {
   beforeEach(() => {
     nock.cleanAll()
@@ -34,7 +36,6 @@ describe('On-chain event helpers', () => {
         .get(`/block/arbitrum/1736525692`)
         .reply(200, mockBlockTimestamp)
 
-      const networkId = NetworkId['arbitrum-one']
       const timestamp = new Date(1736525692000)
       const result = await getNearestBlock(networkId, timestamp)
 
@@ -43,8 +44,6 @@ describe('On-chain event helpers', () => {
   })
 
   describe('getBlockRange', () => {
-    const networkId = NetworkId['arbitrum-one']
-
     it('should return correct start and end blocks for a valid range', async () => {
       nock('https://coins.llama.fi')
         .get('/block/arbitrum/1000')
@@ -125,7 +124,7 @@ describe('On-chain event helpers', () => {
         .reply(200, { height: 9, timestamp: 990 }) // Results in endBlock = 10
 
       const startTimestamp = new Date(1000000)
-      const endTimestamp = new Date(1001000) // et > st, so first validation passes
+      const endTimestamp = new Date(1001000) // endTimestamp > startTimestamp, so first validation passes
 
       await expect(
         getBlockRange({ networkId, startTimestamp, endTimestamp }),
@@ -140,7 +139,6 @@ describe('On-chain event helpers', () => {
       address: '0x123',
       abi: erc20Abi,
     }
-    const networkId = NetworkId['arbitrum-one']
 
     it('should fetch all events over multiple requests based on getBlockRange result', async () => {
       const mockGetContractEvents = jest
@@ -208,7 +206,7 @@ describe('On-chain event helpers', () => {
       const startTimestamp = new Date(1000000)
       const endTimestamp = new Date(1001000) // startTimestamp < endTimestamp is true
 
-      // We expect _fetchEvents to propagate the error thrown by getBlockRange.
+      // We expect fetchEvents to propagate the error thrown by getBlockRange.
       await expect(
         fetchEvents({
           contract: mockContract,

--- a/scripts/calculateRevenue/protocols/utils/events.test.ts
+++ b/scripts/calculateRevenue/protocols/utils/events.test.ts
@@ -13,6 +13,7 @@ import { erc20Abi, GetContractReturnType } from 'viem'
 // so it doesn't interfere with the tests.
 jest.mock('@github/memoize', () => ({
   __esModule: true,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   default: (fn: any) => fn,
 }))
 

--- a/scripts/calculateRevenue/protocols/utils/events.test.ts
+++ b/scripts/calculateRevenue/protocols/utils/events.test.ts
@@ -156,7 +156,7 @@ describe('On-chain event helpers', () => {
         .reply(200, { height: 0, timestamp: 0 })
       nock('https://coins.llama.fi')
         .get('/block/arbitrum/1')
-        .reply(200, { height: 15000, timestamp: 1 })
+        .reply(200, { height: 15000, timestamp: 1000 })
 
       const startTimestamp = new Date(0)
       const endTimestamp = new Date(1000)

--- a/scripts/calculateRevenue/protocols/utils/events.ts
+++ b/scripts/calculateRevenue/protocols/utils/events.ts
@@ -117,9 +117,9 @@ export async function getBlockRange({
   ])
 
   // Validate the calculated block range.
-  // The startBlock must be strictly less than the endBlock for a valid, non-empty range.
-  // If startBlock == endBlock, the range is empty (e.g., startTimestamp and endTimestamp map to the same block for their >= condition).
-  // If startBlock > endBlock, it implies an issue, possibly with startTimestamp mapping to a block after endTimestamp's mapped block,
+  // The startBlock must be strictly less than the endBlockExclusive for a valid, non-empty range.
+  // If startBlock == endBlockExclusive, the range is empty (e.g., startTimestamp and endTimestamp map to the same block for their >= condition).
+  // If startBlock > endBlockExclusive, it implies an issue, possibly with startTimestamp mapping to a block after endTimestamp's mapped block,
   // though the initial timestamp check should largely prevent this specific sequence.
   if (startBlock >= endBlockExclusive) {
     throw new Error(

--- a/scripts/calculateRevenue/protocols/utils/events.ts
+++ b/scripts/calculateRevenue/protocols/utils/events.ts
@@ -110,8 +110,8 @@ export async function getBlockRange({
     getFirstBlockAtOrAfterTimestamp(networkId, startTimestamp),
     // Determine the exclusive endBlock:
     // This is the first block whose timestamp is greater than or equal to the endTimestamp.
-    // Using this block's height as `endBlock` means that loops iterating up to `endBlock - 1`
-    // will process all blocks strictly before this `endBlock`.
+    // Using this block's height as `endBlockExclusive` means that loops iterating up to `endBlockExclusive - 1`
+    // will process all blocks strictly before this `endBlockExclusive`.
     // Thus, the last processed block will have a timestamp < endTimestamp.
     getFirstBlockAtOrAfterTimestamp(networkId, endTimestamp),
   ])

--- a/scripts/calculateRevenue/protocols/utils/events.ts
+++ b/scripts/calculateRevenue/protocols/utils/events.ts
@@ -81,9 +81,9 @@ async function getFirstBlockAtOrAfterTimestamp(
  * @param endTimestamp The exclusive end date of the time range.
  * @returns A promise that resolves to an object containing:
  *    `startBlock`: The first block whose timestamp is >= startTimestamp (inclusive).
- *    `endBlock`: The first block whose timestamp is >= endTimestamp. This block itself
+ *    `endBlockExclusive`: The first block whose timestamp is >= endTimestamp. This block itself
  *                is *exclusive* from the desired range. When used in loops like
- *                `for (let i = startBlock; i < endBlock; i++)`, or as an exclusive
+ *                `for (let i = startBlock; i < endBlockExclusive; i++)`, or as an exclusive
  *                upper bound in queries, it correctly defines the desired time window.
  * @throws Will throw an error if startTimestamp is not before endTimestamp, or if a valid
  *         block range cannot be determined (e.g., startBlock ends up >= endBlock).

--- a/scripts/calculateRevenue/protocols/utils/events.ts
+++ b/scripts/calculateRevenue/protocols/utils/events.ts
@@ -26,10 +26,10 @@ const NETWORK_ID_TO_DEFI_LLAMA_CHAIN: Partial<{
  * @returns A promise that resolves to the block number closest to the given timestamp.
  * @throws Will throw an error if the fetch request to DefiLlama fails.
  */
-export async function _getNearestBlock(
+async function _getNearestBlock(
   networkId: NetworkId,
   timestamp: Date,
-): Promise<number> {
+): Promise<BlockTimestampData> {
   const unixTimestamp = Math.floor(timestamp.getTime() / 1000)
   const defiLlamaChain = NETWORK_ID_TO_DEFI_LLAMA_CHAIN[networkId]
 
@@ -42,12 +42,93 @@ export async function _getNearestBlock(
     )
   }
   const blockTimestampData = (await response.json()) as BlockTimestampData
-  return blockTimestampData.height
+  return blockTimestampData
 }
 
-export const getNearestBlock = memoize(_getNearestBlock, {
+/**
+ * Intentionally not exported. We should use `getBlockRange` instead.
+ */
+const getNearestBlock = memoize(_getNearestBlock, {
   hash: (...params: Parameters<typeof _getNearestBlock>) => params.join(','),
 })
+
+export const _getNearestBlockForTesting = getNearestBlock
+
+async function getFirstBlockAtOrAfterTimestamp(
+  networkId: NetworkId,
+  targetDate: Date,
+): Promise<number> {
+  const targetTimestampSec = Math.floor(targetDate.getTime() / 1000)
+  const block = await getNearestBlock(networkId, targetDate)
+
+  if (block.timestamp >= targetTimestampSec) {
+    // The nearest block is at or after the target. It must be the first.
+    return block.height
+  } else {
+    // The nearest block is before the target. The next block must be the first one at or after.
+    // Note: Assumes block numbers increment by 1 and block N+1 always has timestamp >= block N.
+    return block.height + 1
+  }
+}
+
+/**
+ * Calculates the start and end block numbers for a given time range.
+ * The time range is defined as [startTimestamp, endTimestamp),
+ * meaning it's inclusive of the startTimestamp and exclusive of the endTimestamp.
+ *
+ * @param networkId The ID of the network.
+ * @param startTimestamp The inclusive start date of the time range.
+ * @param endTimestamp The exclusive end date of the time range.
+ * @returns A promise that resolves to an object containing:
+ *    `startBlock`: The first block whose timestamp is >= startTimestamp (inclusive).
+ *    `endBlock`: The first block whose timestamp is >= endTimestamp. This block itself
+ *                is *exclusive* from the desired range. When used in loops like
+ *                `for (let i = startBlock; i < endBlock; i++)`, or as an exclusive
+ *                upper bound in queries, it correctly defines the desired time window.
+ * @throws Will throw an error if startTimestamp is not before endTimestamp, or if a valid
+ *         block range cannot be determined (e.g., startBlock ends up >= endBlock).
+ */
+export async function getBlockRange({
+  networkId,
+  startTimestamp,
+  endTimestamp,
+}: {
+  networkId: NetworkId
+  startTimestamp: Date // inclusive
+  endTimestamp: Date // exclusive
+}): Promise<{
+  startBlock: number // inclusive
+  endBlockExclusive: number
+}> {
+  if (startTimestamp.getTime() >= endTimestamp.getTime()) {
+    throw new Error('Start timestamp must be before end timestamp.')
+  }
+
+  const [startBlock, endBlockExclusive] = await Promise.all([
+    // Determine the inclusive startBlock:
+    // This is the first block whose timestamp is greater than or equal to the startTimestamp.
+    getFirstBlockAtOrAfterTimestamp(networkId, startTimestamp),
+    // Determine the exclusive endBlock:
+    // This is the first block whose timestamp is greater than or equal to the endTimestamp.
+    // Using this block's height as `endBlock` means that loops iterating up to `endBlock - 1`
+    // will process all blocks strictly before this `endBlock`.
+    // Thus, the last processed block will have a timestamp < endTimestamp.
+    getFirstBlockAtOrAfterTimestamp(networkId, endTimestamp),
+  ])
+
+  // Validate the calculated block range.
+  // The startBlock must be strictly less than the endBlock for a valid, non-empty range.
+  // If startBlock == endBlock, the range is empty (e.g., startTimestamp and endTimestamp map to the same block for their >= condition).
+  // If startBlock > endBlock, it implies an issue, possibly with startTimestamp mapping to a block after endTimestamp's mapped block,
+  // though the initial timestamp check should largely prevent this specific sequence.
+  if (startBlock >= endBlockExclusive) {
+    throw new Error(
+      `Calculated startBlock (height: ${startBlock}) is not strictly less than calculated endBlockExclusive (height: ${endBlockExclusive}). This results in an empty or invalid range. Ensure startTimestamp and endTimestamp define a valid, non-empty interval. It's possible the startTimestamp maps to a block that is at or after the endTimestamp's mapped block.`,
+    )
+  }
+
+  return { startBlock, endBlockExclusive }
+}
 
 /**
  * Fetches events from a specified contract within a given time range.
@@ -60,7 +141,7 @@ export const getNearestBlock = memoize(_getNearestBlock, {
  * @param {Date} params.endTimestamp - The end timestamp for the event search.
  * @returns {Promise<Log[]>} A promise that resolves to an array of event logs.
  */
-export async function _fetchEvents({
+async function _fetchEvents({
   contract,
   networkId,
   eventName,
@@ -75,25 +156,34 @@ export async function _fetchEvents({
 }) {
   const client = getViemPublicClient(networkId)
 
-  const startBlock = await getNearestBlock(networkId, startTimestamp)
-  const endBlock = await getNearestBlock(networkId, endTimestamp)
-  const blocksPer = 10000
+  const { startBlock, endBlockExclusive } = await getBlockRange({
+    networkId,
+    startTimestamp,
+    endTimestamp,
+  })
+  const blocksPerQuery = 10000
   let currentBlock = startBlock
-
   const events = []
 
-  while (currentBlock <= endBlock) {
-    const toBlock = Math.min(currentBlock + blocksPer, endBlock)
+  // Loop from startBlock up to (but not including) endBlock
+  while (currentBlock < endBlockExclusive) {
+    // The toBlock for getContractEvents is inclusive.
+    // So, it should be currentBlock + blocksPerQuery - 1, but not exceeding endBlock - 1.
+    const toBlockForQuery = Math.min(
+      currentBlock + blocksPerQuery - 1,
+      endBlockExclusive - 1,
+    )
+
     const eventLogs = await client.getContractEvents({
       address: contract.address,
       abi: contract.abi,
       eventName,
       fromBlock: BigInt(currentBlock),
-      toBlock: BigInt(toBlock),
+      toBlock: BigInt(toBlockForQuery),
     })
 
     events.push(...eventLogs)
-    currentBlock = toBlock + 1
+    currentBlock = toBlockForQuery + 1
   }
   return events
 }

--- a/scripts/calculateRevenue/protocols/utils/events.ts
+++ b/scripts/calculateRevenue/protocols/utils/events.ts
@@ -86,7 +86,7 @@ async function getFirstBlockAtOrAfterTimestamp(
  *                `for (let i = startBlock; i < endBlockExclusive; i++)`, or as an exclusive
  *                upper bound in queries, it correctly defines the desired time window.
  * @throws Will throw an error if startTimestamp is not before endTimestamp, or if a valid
- *         block range cannot be determined (e.g., startBlock ends up >= endBlock).
+ *         block range cannot be determined (e.g., startBlock ends up >= endBlockExclusive).
  */
 export async function getBlockRange({
   networkId,

--- a/scripts/calculateRevenue/protocols/utils/networks.test.ts
+++ b/scripts/calculateRevenue/protocols/utils/networks.test.ts
@@ -56,7 +56,7 @@ describe('fetchTotalTransactionFees', () => {
       networkId,
       users,
       startBlock: 0,
-      endBlock: 100,
+      endBlockExclusive: 100,
     })
 
     expect(result).toBe(

--- a/scripts/calculateRevenue/protocols/utils/networks.ts
+++ b/scripts/calculateRevenue/protocols/utils/networks.ts
@@ -7,12 +7,12 @@ export async function fetchTotalTransactionFees({
   networkId,
   users,
   startBlock,
-  endBlock,
+  endBlockExclusive,
 }: {
   networkId: NetworkId
   users: string[]
-  startBlock?: number
-  endBlock?: number
+  startBlock?: number // inclusive
+  endBlockExclusive?: number
 }): Promise<number> {
   let totalTransactionFees = 0
 
@@ -24,7 +24,7 @@ export async function fetchTotalTransactionFees({
       transaction: [TransactionField.GasUsed, TransactionField.GasPrice],
     },
     fromBlock: startBlock ?? 0,
-    ...(endBlock && { toBlock: endBlock }),
+    ...(endBlockExclusive && { toBlock: endBlockExclusive }),
   }
 
   await paginateQuery(client, query, async (response) => {
@@ -40,12 +40,12 @@ export async function fetchTotalTransactions({
   networkId,
   users,
   startBlock,
-  endBlock,
+  endBlockExclusive,
 }: {
   networkId: NetworkId
   users: string[]
-  startBlock?: number
-  endBlock?: number
+  startBlock?: number // inclusive
+  endBlockExclusive?: number
 }): Promise<number> {
   let totalTransactions = 0
 
@@ -57,7 +57,7 @@ export async function fetchTotalTransactions({
       transaction: [TransactionField.Hash],
     },
     fromBlock: startBlock ?? 0,
-    ...(endBlock && { toBlock: endBlock }),
+    ...(endBlockExclusive && { toBlock: endBlockExclusive }),
   }
 
   await paginateQuery(client, query, async (response) => {

--- a/scripts/calculateRewards/e2eTestRewards.ts
+++ b/scripts/calculateRewards/e2eTestRewards.ts
@@ -45,13 +45,13 @@ function parseArgs() {
     })
     .option('start-timestamp', {
       alias: 's',
-      description: 'start timestamp',
+      description: 'start timestamp (inclusive)',
       type: 'string',
       demandOption: true,
     })
     .option('end-timestamp', {
       alias: 'e',
-      description: 'end timestamp',
+      description: 'end timestamp (exclusive)',
       type: 'string',
       demandOption: true,
     })

--- a/scripts/calculateRewards/proofOfImpact.ts
+++ b/scripts/calculateRewards/proofOfImpact.ts
@@ -82,13 +82,13 @@ function parseArgs() {
     })
     .option('start-timestamp', {
       alias: 's',
-      description: 'start timestamp',
+      description: 'start timestamp (inclusive)',
       type: 'string',
       demandOption: true,
     })
     .option('end-timestamp', {
       alias: 'e',
-      description: 'end timestamp',
+      description: 'end timestamp (exclusive)',
       type: 'string',
       demandOption: true,
     })

--- a/scripts/getDivviIntegrators.ts
+++ b/scripts/getDivviIntegrators.ts
@@ -15,8 +15,9 @@ import { NetworkId } from './types'
 import { divviRegistryAbi } from '../abis/DivviRegistry'
 import { rewardPoolAbi } from '../abis/RewardPool'
 import { fetchWithTimeout } from './utils/fetchWithTimeout'
-import { getNearestBlock } from './calculateRevenue/protocols/utils/events'
+import { getBlockRange } from './calculateRevenue/protocols/utils/events'
 import { createAddRewardSafeTransactionJSON } from './utils/createSafeTransactionsBatch'
+
 const DIVVI_REGISTRY_CONTRACT_ADDRESS =
   '0xEdb51A8C390fC84B1c2a40e0AE9C9882Fa7b7277'
 const DIVVI_INTEGRATION_REWARDS_ENTITY =
@@ -122,14 +123,15 @@ async function getDivviIntegrators({
     eventName: 'ReferralRegistered',
   })[0]
 
-  const [startBlock, endBlock] = await Promise.all([
-    getNearestBlock(NetworkId['op-mainnet'], startTimestamp),
-    getNearestBlock(NetworkId['op-mainnet'], endTimestamp),
-  ])
+  const { startBlock, endBlockExclusive } = await getBlockRange({
+    networkId: NetworkId['op-mainnet'],
+    startTimestamp,
+    endTimestamp,
+  })
 
   const queryForIntegrators = {
     fromBlock: startBlock,
-    toBlock: endBlock,
+    toBlock: endBlockExclusive,
     logs: [
       {
         address: [DIVVI_REGISTRY_CONTRACT_ADDRESS],


### PR DESCRIPTION
As the title says. 

This fixes subtle off-by-one errors we had due to HyperSync / RPC node not treating the "to block" the same way (exclusive vs inclusive).
Also `startTimestamp` is now guaranteed to be included and `endTimestamp` excluded.

The main changes are in `events.ts` and its unit tests. The rest is adapting existing code to call the new method.

Part of ENG-365