### PR TITLE
refactor: remove input and output file name args for scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,6 +120,3 @@ gha-creds-*.json
 # solidity-coverage files
 /coverage
 /coverage.json
-
-# CSV Output files at the root
-*.csv

--- a/scripts/calculateRevenue.ts
+++ b/scripts/calculateRevenue.ts
@@ -1,23 +1,33 @@
 import calculateRevenueHandlers from './calculateRevenue/protocols'
 import { parse } from 'csv-parse/sync'
 import { stringify } from 'csv-stringify/sync'
-import { readFileSync, writeFileSync } from 'fs'
+import { mkdirSync, readFileSync, writeFileSync } from 'fs'
 import yargs from 'yargs'
-import { protocols, Protocol } from './types'
+import { protocols } from './types'
+import { toPeriodFolderName } from './utils/dateFormatting'
+import { dirname } from 'path'
 
 // Buffer to account for time it takes for a referral to be registered, since the referral transaction is made first and the referral registration happens on a schedule
 const REFERRAL_TIME_BUFFER_IN_SECONDS = 30 * 60 // 30 minutes
 
 async function main(args: ReturnType<typeof parseArgs>) {
-  const inputFile = args['input-file'] ?? `${args['protocol']}-referrals.csv`
-  const outputFile = args['output-file'] ?? `${args['protocol']}-revenue.csv`
+  const startTimestamp = new Date(args['start-timestamp'])
+  const endTimestamp = new Date(args['end-timestamp'])
+  const protocol = args.protocol
+
+  const folderPath = `rewards/${protocol}/${toPeriodFolderName({
+    startTimestamp,
+    endTimestamp,
+  })}`
+  const inputFile = `${folderPath}/referrals.csv`
+  const outputFile = `${folderPath}/revenue.csv`
 
   const eligibleUsers = parse(readFileSync(inputFile, 'utf-8').toString(), {
     skip_empty_lines: true,
     delimiter: ',',
     columns: true,
   })
-  const handler = calculateRevenueHandlers[args['protocol'] as Protocol]
+  const handler = calculateRevenueHandlers[protocol]
 
   const allResults: Array<{
     referrerId: string
@@ -34,7 +44,6 @@ async function main(args: ReturnType<typeof parseArgs>) {
     const referralTimestamp = new Date(
       timestamp - REFERRAL_TIME_BUFFER_IN_SECONDS,
     )
-    const endTimestamp = new Date(args['end-timestamp'])
     if (referralTimestamp.getTime() > endTimestamp.getTime()) {
       console.log(
         `Referral date is after end date, skipping ${userAddress} (referral date: ${new Date(timestamp).toISOString()})`,
@@ -42,7 +51,6 @@ async function main(args: ReturnType<typeof parseArgs>) {
       continue
     }
 
-    const startTimestamp = new Date(args['start-timestamp'])
     const revenue = await handler({
       address: userAddress,
       // if the referral happened after the start of the period, only calculate revenue from the referral block onwards so that we exclude user activity before the referral
@@ -59,6 +67,8 @@ async function main(args: ReturnType<typeof parseArgs>) {
     })
   }
 
+  // Create directory if it doesn't exist
+  mkdirSync(dirname(outputFile), { recursive: true })
   writeFileSync(outputFile, stringify(allResults, { header: true }), {
     encoding: 'utf-8',
   })
@@ -68,18 +78,6 @@ async function main(args: ReturnType<typeof parseArgs>) {
 
 function parseArgs() {
   return yargs
-    .option('input-file', {
-      alias: 'i',
-      description: 'input file path of referrals, newline separated',
-      type: 'string',
-      demandOption: false,
-    })
-    .option('output-file', {
-      alias: 'o',
-      description: 'output file path to write csv results',
-      type: 'string',
-      demandOption: false,
-    })
     .option('protocol', {
       alias: 'p',
       description: 'ID of protocol to check against',

--- a/scripts/calculateRewards/celoPG.ts
+++ b/scripts/calculateRewards/celoPG.ts
@@ -4,6 +4,7 @@ import { readFileSync } from 'fs'
 import { parseEther } from 'viem'
 import BigNumber from 'bignumber.js'
 import { createAddRewardSafeTransactionJSON } from '../utils/createSafeTransactionsBatch'
+import { toPeriodFolderName } from '../utils/dateFormatting'
 
 const REWARD_POOL_ADDRESS = '0xc273fB49C5c291F7C697D0FcEf8ce34E985008F3' // on Celo mainnet
 
@@ -48,18 +49,6 @@ export function calculateRewardsCeloPG({
 
 function parseArgs() {
   return yargs
-    .option('input-file', {
-      alias: 'i',
-      description: 'input file path containing revenue data',
-      type: 'string',
-      demandOption: true,
-    })
-    .option('output-file', {
-      alias: 'o',
-      description: 'output file path to write reward allocations',
-      type: 'string',
-      demandOption: false,
-    })
     .option('start-timestamp', {
       alias: 's',
       description: 'start timestamp',
@@ -89,8 +78,15 @@ interface KpiRow {
 }
 
 async function main(args: ReturnType<typeof parseArgs>) {
-  const inputPath = args['input-file']
-  const outputPath = args['output-file'] ?? 'celo-pg-safe-transactions.json'
+  const startTimestamp = new Date(args['start-timestamp'])
+  const endTimestamp = new Date(args['end-timestamp'])
+
+  const folderPath = `rewards/celo-pg/${toPeriodFolderName({
+    startTimestamp,
+    endTimestamp,
+  })}`
+  const inputPath = `${folderPath}/revenue.csv`
+  const outputPath = `${folderPath}/safe-transactions.json`
   const rewardAmount = args['reward-amount']
 
   const kpiData = parse(readFileSync(inputPath, 'utf-8').toString(), {
@@ -108,8 +104,8 @@ async function main(args: ReturnType<typeof parseArgs>) {
     filePath: outputPath,
     rewardPoolAddress: REWARD_POOL_ADDRESS,
     rewards,
-    startTimestamp: args['start-timestamp'],
-    endTimestamp: args['end-timestamp'],
+    startTimestamp,
+    endTimestamp,
   })
 }
 

--- a/scripts/calculateRewards/e2eTestRewards.ts
+++ b/scripts/calculateRewards/e2eTestRewards.ts
@@ -84,8 +84,8 @@ async function main(args: ReturnType<typeof parseArgs>) {
     filePath: outputPath,
     rewardPoolAddress: REWARD_POOL_ADDRESS,
     rewards,
-    startTimestamp: args['start-timestamp'],
-    endTimestamp: args['end-timestamp'],
+    startTimestamp: new Date(args['start-timestamp']),
+    endTimestamp: new Date(args['end-timestamp']),
   })
 }
 

--- a/scripts/calculateRewards/proofOfImpact.test.ts
+++ b/scripts/calculateRewards/proofOfImpact.test.ts
@@ -5,10 +5,10 @@ import {
 import BigNumber from 'bignumber.js'
 
 describe('calculateRewardsProofOfImpact', () => {
-  const startTimestamp = '1746687600000' // May 8 2025 12:00:00 AM UTC
-  const endTimestamp = '1747267200000' // May 15 2025 12:00:00 AM UTC
+  const startTimestamp = new Date('2025-05-08')
+  const endTimestamp = new Date('2025-05-15')
   const expectedTotalRewardsForPeriod = _rewardsPerMillisecond.times(
-    new BigNumber(endTimestamp).minus(startTimestamp),
+    new BigNumber(endTimestamp.getTime()).minus(startTimestamp.getTime()),
   )
 
   it('should calculate rewards proportionally based on revenue', () => {

--- a/scripts/getDivviIntegrators.ts
+++ b/scripts/getDivviIntegrators.ts
@@ -271,8 +271,8 @@ async function main() {
         referrerId: address,
         rewardAmount: DIVVI_REWARD_AMOUNT.toString(),
       })),
-      startTimestamp: args.startTimestamp.getTime().toString(),
-      endTimestamp: args.endTimestamp.getTime().toString(),
+      startTimestamp: args.startTimestamp,
+      endTimestamp: args.endTimestamp,
     })
   }
 }

--- a/scripts/utils/createSafeTransactionsBatch.test.ts
+++ b/scripts/utils/createSafeTransactionsBatch.test.ts
@@ -25,8 +25,8 @@ describe('createAddRewardSafeTransactionJSON', () => {
       rewardAmount: '2000000000000000000', // 2 ETH in wei
     },
   ]
-  const mockStartTimestamp = '1677649200' // March 1, 2023
-  const mockEndTimestamp = '1680327600' // April 1, 2023
+  const mockStartTimestamp = new Date('2023-03-01')
+  const mockEndTimestamp = new Date('2023-04-01')
 
   beforeEach(() => {
     jest.clearAllMocks()

--- a/scripts/utils/createSafeTransactionsBatch.test.ts
+++ b/scripts/utils/createSafeTransactionsBatch.test.ts
@@ -25,8 +25,8 @@ describe('createAddRewardSafeTransactionJSON', () => {
       rewardAmount: '2000000000000000000', // 2 ETH in wei
     },
   ]
-  const mockStartTimestamp = new Date('2023-03-01')
-  const mockEndTimestamp = new Date('2023-04-01')
+  const mockStartTimestamp = new Date('2023-03-01T00:00:00Z')
+  const mockEndTimestamp = new Date('2023-04-01T00:00:00Z')
 
   beforeEach(() => {
     jest.clearAllMocks()
@@ -83,7 +83,7 @@ describe('createAddRewardSafeTransactionJSON', () => {
             users:
               '[0x1111111111111111111111111111111111111111, 0x2222222222222222222222222222222222222222]',
             amounts: '[1000000000000000000, 2000000000000000000]',
-            rewardFunctionArgs: '[1677649200, 1680327600]',
+            rewardFunctionArgs: '[1677628800, 1680307200]',
           },
         },
       ],

--- a/scripts/utils/createSafeTransactionsBatch.ts
+++ b/scripts/utils/createSafeTransactionsBatch.ts
@@ -56,7 +56,10 @@ export const createAddRewardSafeTransactionJSON = ({
         contractInputsValues: {
           users: `[${users.join(', ')}]`,
           amounts: `[${amounts.join(', ')}]`,
-          rewardFunctionArgs: `[${BigInt(startTimestamp.getTime())}, ${BigInt(endTimestamp.getTime())}]`,
+          // Convert timestamps to seconds
+          rewardFunctionArgs: `[${BigInt(startTimestamp.getTime() / 1000)}, ${BigInt(
+            endTimestamp.getTime() / 1000,
+          )}]`,
         },
       },
     ],

--- a/scripts/utils/createSafeTransactionsBatch.ts
+++ b/scripts/utils/createSafeTransactionsBatch.ts
@@ -14,8 +14,8 @@ export const createAddRewardSafeTransactionJSON = ({
     referrerId: string
     rewardAmount: string // in smallest unit of reward token
   }[]
-  startTimestamp: string
-  endTimestamp: string
+  startTimestamp: Date
+  endTimestamp: Date
 }) => {
   const users: string[] = []
   const amounts: string[] = []
@@ -56,7 +56,7 @@ export const createAddRewardSafeTransactionJSON = ({
         contractInputsValues: {
           users: `[${users.join(', ')}]`,
           amounts: `[${amounts.join(', ')}]`,
-          rewardFunctionArgs: `[${BigInt(startTimestamp)}, ${BigInt(endTimestamp)}]`,
+          rewardFunctionArgs: `[${BigInt(startTimestamp.getTime())}, ${BigInt(endTimestamp.getTime())}]`,
         },
       },
     ],

--- a/scripts/utils/dateFormatting.ts
+++ b/scripts/utils/dateFormatting.ts
@@ -1,0 +1,16 @@
+// Returns a folder name in the format of YYYY-MM-DDTHH-MM-SSZ_YYYY-MM-DDTHH-MM-SSZ
+export function toPeriodFolderName({
+  startTimestamp,
+  endTimestamp,
+}: {
+  startTimestamp: Date
+  endTimestamp: Date
+}) {
+  const formatDate = (date: Date): string =>
+    date.toISOString().substring(0, 19).replace(/:/g, '-') + 'Z'
+
+  const safeStart = formatDate(startTimestamp)
+  const safeEnd = formatDate(endTimestamp)
+
+  return `${safeStart}_${safeEnd}`
+}


### PR DESCRIPTION
We need to run 3 scripts to do the reward distributions, and each script requires us to declare the input and output file paths. Each file path depends on the reward period start and end times. This is cumbersome and there is room for copy and paste errors when creating the file paths.

This PR proposes the following changes:
- we pass the start and end timestamp to all scripts (currently not needed for `fetchReferrals`) - this might make it easy to eventually automate and declare these variables one time?
- the input and output file paths are determined in code and use the start and end timestamps + protocol
- the folder names will look like `rewards/{{protocol}}/2025-05-08T00-00-00Z_2025-05-15T00-00-00Z` which i personally find more readable than 2 unix timestamps, and still allows sorting alphabetically + chronologically
- the file names will continue to be `referrals.csv`, `revenue.csv`, `safe-transactions.json`
- a sequence of reward distribution commands will look like (for celo PoI):
```
yarn ts-node scripts/fetchReferrals.ts --protocol=celo-transactions --start-timestamp=2025-05-08T00:00:00Z --end-timestamp=2025-05-15T00:00:00Z --builder-allowlist-file=builder-allowlist.csv
yarn ts-node scripts/calculateRevenue.ts --protocol=celo-transactions --start-timestamp=2025-05-08T00:00:00Z --end-timestamp=2025-05-15T00:00:00Z
yarn ts-node scripts/calculateRewards/proofOfImpact.ts --start-timestamp=2025-05-08T00:00:00Z --end-timestamp=2025-05-15T00:00:00Z
```

The downside is that the scripts expect certain input files to exist and we are less free to run the scripts in isolation, but I think this is not a real scenario that is worth optimising for.