### PR TITLE
fix: ensure builder allowlist format and passed to filter

### DIFF
--- a/scripts/fetchReferrals.ts
+++ b/scripts/fetchReferrals.ts
@@ -5,6 +5,7 @@ import { fetchReferralEvents, removeDuplicates } from './utils/referrals'
 import { Protocol, protocols } from './types'
 import { stringify } from 'csv-stringify/sync'
 import { Address } from 'viem'
+import { parse } from 'csv-parse/sync'
 import { toPeriodFolderName } from './utils/dateFormatting'
 import { dirname } from 'path'
 
@@ -62,10 +63,10 @@ async function main() {
   )
   const uniqueEvents = removeDuplicates(referralEvents)
   const builderAllowList = args.builderAllowList
-    ? readFileSync(args.builderAllowList, 'utf-8')
-        .split('\n')
-        .map((line) => line.trim() as Address)
-        .filter((line) => line.length > 0) // Remove empty lines
+    ? parse(readFileSync(args.builderAllowList, 'utf-8').toString(), {
+        skip_empty_lines: true,
+        columns: true,
+      }).map(({ referrerId }: { referrerId: Address }) => referrerId)
     : undefined
 
   const filteredEvents = await args.protocolFilter(

--- a/scripts/fetchReferrals.ts
+++ b/scripts/fetchReferrals.ts
@@ -5,7 +5,6 @@ import { fetchReferralEvents, removeDuplicates } from './utils/referrals'
 import { Protocol, protocols } from './types'
 import { stringify } from 'csv-stringify/sync'
 import { Address } from 'viem'
-import { parse } from 'csv-parse/sync'
 import { toPeriodFolderName } from './utils/dateFormatting'
 import { dirname } from 'path'
 
@@ -63,11 +62,10 @@ async function main() {
   )
   const uniqueEvents = removeDuplicates(referralEvents)
   const builderAllowList = args.builderAllowList
-    ? (parse(readFileSync(args.builderAllowList, 'utf-8').toString(), {
-        skip_empty_lines: true,
-        delimiter: ',',
-        columns: true,
-      }) as Address[])
+    ? readFileSync(args.builderAllowList, 'utf-8')
+        .split('\n')
+        .map((line) => line.trim() as Address)
+        .filter((line) => line.length > 0) // Remove empty lines
     : undefined
 
   const filteredEvents = await args.protocolFilter(

--- a/scripts/fetchReferrals.ts
+++ b/scripts/fetchReferrals.ts
@@ -1,4 +1,4 @@
-import { writeFileSync, readFileSync, mkdirSync } from 'fs'
+import { writeFileSync, readFileSync, mkdirSync, copyFileSync } from 'fs'
 import yargs from 'yargs'
 import { protocolFilters } from './protocolFilters'
 import { fetchReferralEvents, removeDuplicates } from './utils/referrals'
@@ -79,10 +79,11 @@ async function main() {
     timestamp: event.timestamp,
   }))
 
-  const outputFile = `rewards/${args.protocol}/${toPeriodFolderName({
+  const outputDir = `rewards/${args.protocol}/${toPeriodFolderName({
     startTimestamp: new Date(args.startTimestamp),
     endTimestamp: new Date(args.endTimestamp),
-  })}/referrals.csv`
+  })}`
+  const outputFile = `${outputDir}/referrals.csv`
 
   // Create directory if it doesn't exist
   mkdirSync(dirname(outputFile), { recursive: true })
@@ -90,6 +91,12 @@ async function main() {
     encoding: 'utf-8',
   })
   console.log(`Wrote results to ${outputFile}`)
+
+  if (args.builderAllowList) {
+    const allowListOutputFile = `${outputDir}/builder-allowlist.csv`
+    copyFileSync(args.builderAllowList, allowListOutputFile)
+    console.log(`Copied builder allowlist to ${allowListOutputFile}`)
+  }
 }
 
 main().catch((error) => {

--- a/scripts/protocolFilters/index.ts
+++ b/scripts/protocolFilters/index.ts
@@ -8,6 +8,7 @@ import { filter as filterVelodrome } from './velodrome'
 import { filter as filterFonbnk } from './fonbnk'
 import { filter as filterAave } from './aave'
 import { filter as filterCeloTransactions } from './celoTransactions'
+import { Address } from 'viem'
 
 export const protocolFilters: Record<Protocol, FilterFunction> = {
   beefy: _createFilter(filterBeefy),
@@ -21,11 +22,19 @@ export const protocolFilters: Record<Protocol, FilterFunction> = {
   'celo-transactions': _createFilter(filterCeloTransactions),
 }
 
-function _createFilter(filter: (event: ReferralEvent) => Promise<boolean>) {
-  return async function (events: ReferralEvent[]): Promise<ReferralEvent[]> {
+function _createFilter(
+  filter: (
+    event: ReferralEvent,
+    builderAllowList?: Address[],
+  ) => Promise<boolean>,
+) {
+  return async function (
+    events: ReferralEvent[],
+    builderAllowList?: Address[],
+  ): Promise<ReferralEvent[]> {
     const filteredEvents = []
     for (const event of events) {
-      if (await filter(event)) {
+      if (await filter(event, builderAllowList)) {
         filteredEvents.push(event)
       }
     }

--- a/scripts/protocolFilters/index.ts
+++ b/scripts/protocolFilters/index.ts
@@ -8,7 +8,6 @@ import { filter as filterVelodrome } from './velodrome'
 import { filter as filterFonbnk } from './fonbnk'
 import { filter as filterAave } from './aave'
 import { filter as filterCeloTransactions } from './celoTransactions'
-import { Address } from 'viem'
 
 export const protocolFilters: Record<Protocol, FilterFunction> = {
   beefy: _createFilter(filterBeefy),
@@ -23,18 +22,17 @@ export const protocolFilters: Record<Protocol, FilterFunction> = {
 }
 
 function _createFilter(
-  filter: (
-    event: ReferralEvent,
-    builderAllowList?: Address[],
-  ) => Promise<boolean>,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  filter: (event: ReferralEvent, ...args: any[]) => Promise<boolean>,
 ) {
   return async function (
     events: ReferralEvent[],
-    builderAllowList?: Address[],
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ...args: any[]
   ): Promise<ReferralEvent[]> {
     const filteredEvents = []
     for (const event of events) {
-      if (await filter(event, builderAllowList)) {
+      if (await filter(event, ...args)) {
         filteredEvents.push(event)
       }
     }


### PR DESCRIPTION
This PR fixes a couple things:
- parse the allowList into an `Address` array
- pass allowList all the way to the filter

Also, add the allowList to the reward directory because it should be checked in.