### PR TITLE
chore: use ISO 8601 timestamps for directories

### DIFF
--- a/scripts/utils/dateFormatting.ts
+++ b/scripts/utils/dateFormatting.ts
@@ -6,11 +6,5 @@ export function toPeriodFolderName({
   startTimestamp: Date
   endTimestamp: Date
 }) {
-  const formatDate = (date: Date): string =>
-    date.toISOString().substring(0, 19).replace(/:/g, '-') + 'Z'
-
-  const safeStart = formatDate(startTimestamp)
-  const safeEnd = formatDate(endTimestamp)
-
-  return `${safeStart}_${safeEnd}`
+  return `${startTimestamp.toISOString()}_${endTimestamp.toISOString()}`
 }


### PR DESCRIPTION
A well-defined format is useful because it's parseable by js Date or GNU date. We also need more precision for some programs we're running, like Divvi integration rewards.