### PR TITLE
refactor(scripts): rename endTimestamp -> endTimestampExclusive

### DIFF
--- a/scripts/calculateRevenue.ts
+++ b/scripts/calculateRevenue.ts
@@ -12,12 +12,12 @@ const REFERRAL_TIME_BUFFER_IN_SECONDS = 30 * 60 // 30 minutes
 
 async function main(args: ReturnType<typeof parseArgs>) {
   const startTimestamp = new Date(args['start-timestamp'])
-  const endTimestamp = new Date(args['end-timestamp'])
+  const endTimestampExclusive = new Date(args['end-timestamp'])
   const protocol = args.protocol
 
   const folderPath = `rewards/${protocol}/${toPeriodFolderName({
     startTimestamp,
-    endTimestamp,
+    endTimestampExclusive,
   })}`
   const inputFile = `${folderPath}/referrals.csv`
   const outputFile = `${folderPath}/revenue.csv`
@@ -44,7 +44,7 @@ async function main(args: ReturnType<typeof parseArgs>) {
     const referralTimestamp = new Date(
       timestamp - REFERRAL_TIME_BUFFER_IN_SECONDS,
     )
-    if (referralTimestamp.getTime() > endTimestamp.getTime()) {
+    if (referralTimestamp.getTime() > endTimestampExclusive.getTime()) {
       console.log(
         `Referral date is after end date, skipping ${userAddress} (referral date: ${new Date(timestamp).toISOString()})`,
       )
@@ -58,7 +58,7 @@ async function main(args: ReturnType<typeof parseArgs>) {
         referralTimestamp.getTime() > startTimestamp.getTime()
           ? referralTimestamp
           : startTimestamp,
-      endTimestamp,
+      endTimestampExclusive,
     })
     allResults.push({
       referrerId,

--- a/scripts/calculateRevenue/protocols/aave/blockchainData/index.ts
+++ b/scripts/calculateRevenue/protocols/aave/blockchainData/index.ts
@@ -11,7 +11,7 @@ export async function fetchBlockchainData(
   network: SupportedNetwork,
   userAddress: Address,
   startTimestamp: Date,
-  endTimestamp: Date,
+  endTimestampExclusive: Date,
 ) {
   const {
     networkId,
@@ -24,7 +24,7 @@ export async function fetchBlockchainData(
   const { startBlock, endBlockExclusive } = await getBlockRange({
     networkId,
     startTimestamp,
-    endTimestamp,
+    endTimestampExclusive,
   })
   // For state at the end of the period, use the last inclusive block
   const endBlockInclusive = endBlockExclusive - 1
@@ -58,7 +58,7 @@ export async function fetchBlockchainData(
       subgraphId,
       userAddress,
       startTimestamp,
-      endTimestamp,
+      endTimestampExclusive,
     }),
     getUSDPrices({
       networkId,

--- a/scripts/calculateRevenue/protocols/aave/blockchainData/subgraph.ts
+++ b/scripts/calculateRevenue/protocols/aave/blockchainData/subgraph.ts
@@ -25,12 +25,12 @@ export async function getATokenScaledBalanceHistory({
   subgraphId,
   userAddress,
   startTimestamp,
-  endTimestamp,
+  endTimestampExclusive,
 }: {
   subgraphId: string
   userAddress: Address
   startTimestamp: Date
-  endTimestamp: Date
+  endTimestampExclusive: Date
 }): Promise<Map<Address, BalanceSnapshot[]>> {
   const subgraphUrl = new URL(subgraphId, SUBGRAPH_BASE_URL).toString()
 
@@ -44,7 +44,7 @@ export async function getATokenScaledBalanceHistory({
     query getUserReservesHistory(
       $userAddress: String!
       $startTimestamp: Int!
-      $endTimestamp: Int!
+      $endTimestampExclusive: Int!
     ) {
       userReserves(where: { user: $userAddress }) {
         reserve {
@@ -53,7 +53,10 @@ export async function getATokenScaledBalanceHistory({
           }
         }
         aTokenBalanceHistory(
-          where: { timestamp_gte: $startTimestamp, timestamp_lt: $endTimestamp }
+          where: {
+            timestamp_gte: $startTimestamp
+            timestamp_lt: $endTimestampExclusive
+          }
           orderBy: timestamp
           orderDirection: asc
         ) {
@@ -68,7 +71,7 @@ export async function getATokenScaledBalanceHistory({
   const data = await client.request<AaveUserReservesResponse>(query, {
     userAddress: userAddress.toLowerCase(),
     startTimestamp: Math.floor(startTimestamp.getTime() / 1000),
-    endTimestamp: Math.floor(endTimestamp.getTime() / 1000),
+    endTimestampExclusive: Math.floor(endTimestampExclusive.getTime() / 1000),
   })
 
   const result = new Map(

--- a/scripts/calculateRevenue/protocols/aave/index.ts
+++ b/scripts/calculateRevenue/protocols/aave/index.ts
@@ -6,11 +6,11 @@ import { fetchBlockchainData } from './blockchainData'
 export async function calculateRevenue({
   address,
   startTimestamp,
-  endTimestamp,
+  endTimestampExclusive,
 }: {
   address: string
   startTimestamp: Date
-  endTimestamp: Date
+  endTimestampExclusive: Date
 }): Promise<number> {
   let revenue = new BigNumber(0)
 
@@ -20,7 +20,7 @@ export async function calculateRevenue({
         network,
         address as Address,
         startTimestamp,
-        endTimestamp,
+        endTimestampExclusive,
       ),
     )
   }
@@ -32,13 +32,13 @@ export async function revenueInNetwork(
   network: SupportedNetwork,
   userAddress: Address,
   startTimestamp: Date,
-  endTimestamp: Date,
+  endTimestampExclusive: Date,
 ): Promise<BigNumber> {
   const chainData = await fetchBlockchainData(
     network,
     userAddress,
     startTimestamp,
-    endTimestamp,
+    endTimestampExclusive,
   )
 
   // TODO: Implement revenue calculation logic

--- a/scripts/calculateRevenue/protocols/aerodrome/index.ts
+++ b/scripts/calculateRevenue/protocols/aerodrome/index.ts
@@ -7,16 +7,16 @@ import { calculateRevenueDrome } from '../utils/drome/calculateRevenueDrome'
 export async function calculateRevenue({
   address,
   startTimestamp,
-  endTimestamp,
+  endTimestampExclusive,
 }: {
   address: string
   startTimestamp: Date
-  endTimestamp: Date
+  endTimestampExclusive: Date
 }): Promise<number> {
   return calculateRevenueDrome({
     address,
     startTimestamp,
-    endTimestamp,
+    endTimestampExclusive,
     supportedLiquidityPoolAddresses:
       AERODROME_SUPPORTED_LIQUIDITY_POOL_ADDRESSES,
     networkId: AERODROME_NETWORK_ID,

--- a/scripts/calculateRevenue/protocols/arbitrum/index.ts
+++ b/scripts/calculateRevenue/protocols/arbitrum/index.ts
@@ -5,16 +5,16 @@ import { fetchTotalTransactionFees } from '../utils/networks'
 export async function calculateRevenue({
   address,
   startTimestamp,
-  endTimestamp,
+  endTimestampExclusive,
 }: {
   address: string
   startTimestamp: Date
-  endTimestamp: Date
+  endTimestampExclusive: Date
 }): Promise<number> {
   const { startBlock, endBlockExclusive } = await getBlockRange({
     networkId: NetworkId['arbitrum-one'],
     startTimestamp,
-    endTimestamp,
+    endTimestampExclusive,
   })
 
   return await fetchTotalTransactionFees({

--- a/scripts/calculateRevenue/protocols/beefy/getVaults.test.ts
+++ b/scripts/calculateRevenue/protocols/beefy/getVaults.test.ts
@@ -122,8 +122,12 @@ describe('getVaults', () => {
 
     const address = '0x123'
     const startTimestamp = new Date(100)
-    const endTimestamp = new Date(200)
-    const result = await getVaults(address, startTimestamp, endTimestamp)
+    const endTimestampExclusive = new Date(200)
+    const result = await getVaults(
+      address,
+      startTimestamp,
+      endTimestampExclusive,
+    )
 
     const expected: VaultsInfo = {
       'beefy:vault:arbitrum:0x0000000000000000000000000000000000000000': {

--- a/scripts/calculateRevenue/protocols/beefy/getVaults.ts
+++ b/scripts/calculateRevenue/protocols/beefy/getVaults.ts
@@ -22,7 +22,7 @@ const BEEFY_CHAIN_TO_NETWORK_ID: Record<string, NetworkId> = {
 export async function getVaults(
   address: string,
   startTimestamp: Date,
-  endTimestamp: Date,
+  endTimestampExclusive: Date,
 ): Promise<VaultsInfo> {
   const portfolioData = (await fetchInvestorTimeline(address)).filter(
     (tx) => tx.usd_balance !== null,
@@ -60,13 +60,13 @@ export async function getVaults(
         vaultAddress,
         beefyChain,
         startTimestamp,
-        endTimestamp,
+        endTimestampExclusive,
       }),
       feeEvents: await fetchFeeEvents({
         vaultAddress,
         networkId,
         startTimestamp,
-        endTimestamp,
+        endTimestampExclusive,
       }),
     }
   }

--- a/scripts/calculateRevenue/protocols/beefy/helpers.test.ts
+++ b/scripts/calculateRevenue/protocols/beefy/helpers.test.ts
@@ -29,13 +29,13 @@ describe('Beefy revenue calculation helpers', () => {
       const vaultAddress = '0x123'
       const beefyChain = 'celo'
       const startTimestamp = new Date('2025-01-10T16:14:52+00:00')
-      const endTimestamp = new Date('2025-01-13T16:14:52+00:00')
+      const endTimestampExclusive = new Date('2025-01-13T16:14:52+00:00')
 
       const result = await _fetchVaultTvlHistory({
         vaultAddress,
         beefyChain,
         startTimestamp,
-        endTimestamp,
+        endTimestampExclusive,
       })
       expect(result).toEqual(mockVaultTvlData)
     })
@@ -55,13 +55,13 @@ describe('Beefy revenue calculation helpers', () => {
       const vaultAddress = '0x123'
       const beefyChain = 'celo'
       const startTimestamp = new Date('2025-01-10T16:14:52+00:00')
-      const endTimestamp = new Date('2025-01-17T16:14:52+00:00')
+      const endTimestampExclusive = new Date('2025-01-17T16:14:52+00:00')
 
       const result = await _fetchVaultTvlHistory({
         vaultAddress,
         beefyChain,
         startTimestamp,
-        endTimestamp,
+        endTimestampExclusive,
       })
       expect(result).toEqual(mockVaultTvlData)
     })
@@ -100,13 +100,13 @@ describe('Beefy revenue calculation helpers', () => {
       const vaultAddress = '0x123'
       const beefyChain = 'celo'
       const startTimestamp = new Date('2025-01-10T16:14:52+00:00')
-      const endTimestamp = new Date('2025-01-20T16:14:52+00:00')
+      const endTimestampExclusive = new Date('2025-01-20T16:14:52+00:00')
 
       const result = await _fetchVaultTvlHistory({
         vaultAddress,
         beefyChain,
         startTimestamp,
-        endTimestamp,
+        endTimestampExclusive,
       })
       expect(result).toEqual(mockVaultTvlData)
     })
@@ -132,12 +132,12 @@ describe('Beefy revenue calculation helpers', () => {
       const vaultAddress = '0x123'
       const networkId = NetworkId['arbitrum-one']
       const startTimestamp = new Date(0)
-      const endTimestamp = new Date(1000)
+      const endTimestampExclusive = new Date(1000)
       const result = await _fetchFeeEvents({
         vaultAddress,
         networkId,
         startTimestamp,
-        endTimestamp,
+        endTimestampExclusive,
       })
 
       const expected = [

--- a/scripts/calculateRevenue/protocols/beefy/helpers.ts
+++ b/scripts/calculateRevenue/protocols/beefy/helpers.ts
@@ -18,12 +18,12 @@ export async function _fetchFeeEvents({
   vaultAddress,
   networkId,
   startTimestamp,
-  endTimestamp,
+  endTimestampExclusive,
 }: {
   vaultAddress: Address
   networkId: NetworkId
   startTimestamp: Date
-  endTimestamp: Date
+  endTimestampExclusive: Date
 }): Promise<FeeEvent[]> {
   const strategyContract = await getStrategyContract(vaultAddress, networkId)
 
@@ -32,7 +32,7 @@ export async function _fetchFeeEvents({
     networkId,
     eventName: 'ChargedFees',
     startTimestamp,
-    endTimestamp,
+    endTimestampExclusive,
   })
 
   const feeEvents: FeeEvent[] = []
@@ -60,26 +60,26 @@ export async function _fetchVaultTvlHistory({
   vaultAddress,
   beefyChain,
   startTimestamp,
-  endTimestamp,
+  endTimestampExclusive,
 }: {
   vaultAddress: string
   beefyChain: string
   startTimestamp: Date
-  endTimestamp: Date
+  endTimestampExclusive: Date
 }): Promise<BeefyVaultTvlData[]> {
   console.log(`Fetching TVL data for Vault ${vaultAddress} on ${beefyChain}`)
   // This endpoint accepts a maximum of one-week long spans.
   // We need to break down the provided date range into week-long durations.
   const timestamps = []
   let startSectionTimestamp = startTimestamp
-  while (startSectionTimestamp < endTimestamp) {
+  while (startSectionTimestamp < endTimestampExclusive) {
     const startPlusOneWeekTimestamp = new Date(
       startSectionTimestamp.getTime() + ONE_WEEK,
     )
     const endSectionTimestamp =
-      startPlusOneWeekTimestamp < endTimestamp
+      startPlusOneWeekTimestamp < endTimestampExclusive
         ? startPlusOneWeekTimestamp
-        : endTimestamp
+        : endTimestampExclusive
     timestamps.push([startSectionTimestamp, endSectionTimestamp])
     startSectionTimestamp = endSectionTimestamp
   }

--- a/scripts/calculateRevenue/protocols/beefy/index.test.ts
+++ b/scripts/calculateRevenue/protocols/beefy/index.test.ts
@@ -235,7 +235,7 @@ describe('Beefy revenue calculation', () => {
       const result = await calculateRevenue({
         address: '0x123',
         startTimestamp: new Date(0),
-        endTimestamp: new Date(100),
+        endTimestampExclusive: new Date(100),
       })
 
       // 160 USD from Arbitrum, 5 from Ethereum

--- a/scripts/calculateRevenue/protocols/beefy/index.ts
+++ b/scripts/calculateRevenue/protocols/beefy/index.ts
@@ -93,12 +93,12 @@ export async function calculateVaultRevenue(
 
   // Fetch the historical prices of the chain's native token
   const startTimestamp = vaultInfo.feeEvents[0].timestamp
-  const endTimestamp =
+  const endTimestampExclusive =
     vaultInfo.feeEvents[vaultInfo.feeEvents.length - 1].timestamp
   const tokenPrices = await fetchTokenPrices({
     tokenId,
     startTimestamp,
-    endTimestamp,
+    endTimestampExclusive,
   })
 
   let totalUsdContribution = 0
@@ -129,13 +129,17 @@ export async function calculateVaultRevenue(
 export async function calculateRevenue({
   address,
   startTimestamp,
-  endTimestamp,
+  endTimestampExclusive,
 }: {
   address: string
   startTimestamp: Date
-  endTimestamp: Date
+  endTimestampExclusive: Date
 }): Promise<number> {
-  const vaultsInfo = await getVaults(address, startTimestamp, endTimestamp)
+  const vaultsInfo = await getVaults(
+    address,
+    startTimestamp,
+    endTimestampExclusive,
+  )
 
   let totalRevenue = 0
   for (const vaultInfo of Object.values(vaultsInfo)) {

--- a/scripts/calculateRevenue/protocols/celo-pg/index.ts
+++ b/scripts/calculateRevenue/protocols/celo-pg/index.ts
@@ -5,16 +5,16 @@ import { fetchTotalTransactionFees } from '../utils/networks'
 export async function calculateRevenue({
   address,
   startTimestamp,
-  endTimestamp,
+  endTimestampExclusive,
 }: {
   address: string
   startTimestamp: Date
-  endTimestamp: Date
+  endTimestampExclusive: Date
 }): Promise<number> {
   const { startBlock, endBlockExclusive } = await getBlockRange({
     networkId: NetworkId['celo-mainnet'],
     startTimestamp,
-    endTimestamp,
+    endTimestampExclusive,
   })
 
   return await fetchTotalTransactionFees({

--- a/scripts/calculateRevenue/protocols/celoTransactions/index.ts
+++ b/scripts/calculateRevenue/protocols/celoTransactions/index.ts
@@ -5,16 +5,16 @@ import { fetchTotalTransactions } from '../utils/networks'
 export async function calculateRevenue({
   address,
   startTimestamp,
-  endTimestamp,
+  endTimestampExclusive,
 }: {
   address: string
   startTimestamp: Date
-  endTimestamp: Date
+  endTimestampExclusive: Date
 }): Promise<number> {
   const { startBlock, endBlockExclusive } = await getBlockRange({
     networkId: NetworkId['celo-mainnet'],
     startTimestamp,
-    endTimestamp,
+    endTimestampExclusive,
   })
 
   return await fetchTotalTransactions({

--- a/scripts/calculateRevenue/protocols/fonbnk/index.test.ts
+++ b/scripts/calculateRevenue/protocols/fonbnk/index.test.ts
@@ -115,7 +115,7 @@ describe('getUserTransactions', () => {
       address: '0x123',
       payoutWallet: '0x456',
       startTimestamp: new Date('2025-01-01T00:00:00Z'),
-      endTimestamp: new Date('2025-01-03T00:00:00Z'),
+      endTimestampExclusive: new Date('2025-01-03T00:00:00Z'),
       client: mockClient as unknown as HypersyncClient,
       networkId: NetworkId['celo-mainnet'],
     })
@@ -144,7 +144,7 @@ describe('getTotalRevenueUsdFromTransactions', () => {
       transactions: MOCK_FONBNK_TRANSACTIONS,
       networkId: NetworkId['celo-mainnet'],
       startTimestamp: new Date('2025-01-01T00:00:00Z'),
-      endTimestamp: new Date('2025-01-03T00:00:00Z'),
+      endTimestampExclusive: new Date('2025-01-03T00:00:00Z'),
     })
 
     // The first transaction has value of 10000 with 4 decimals which is 1, with a price of 3 that is 3 USD
@@ -189,7 +189,7 @@ describe('calculateRevenue', () => {
     const result = await calculateRevenue({
       address: MOCK_ADDRESS,
       startTimestamp: new Date('2025-01-01T00:00:00Z'),
-      endTimestamp: new Date('2025-01-03T00:00:00Z'),
+      endTimestampExclusive: new Date('2025-01-03T00:00:00Z'),
     })
 
     expect(getFonbnkAssets).toHaveBeenCalledTimes(1)

--- a/scripts/calculateRevenue/protocols/fonbnk/index.ts
+++ b/scripts/calculateRevenue/protocols/fonbnk/index.ts
@@ -17,14 +17,14 @@ export async function getUserTransactions({
   address,
   payoutWallet,
   startTimestamp,
-  endTimestamp,
+  endTimestampExclusive,
   client,
   networkId,
 }: {
   address: Address
   payoutWallet: Address
   startTimestamp: Date
-  endTimestamp: Date
+  endTimestampExclusive: Date
   client: HypersyncClient
   networkId: NetworkId
 }): Promise<FonbnkTransaction[]> {
@@ -48,7 +48,7 @@ export async function getUserTransactions({
         // And that the transfer happened within the time window
         if (
           blockTimestampDate >= startTimestamp &&
-          blockTimestampDate <= endTimestamp
+          blockTimestampDate <= endTimestampExclusive
         ) {
           transactions.push({
             amount: fromHex(transaction.data as Address, 'bigint'),
@@ -70,12 +70,12 @@ export async function getTotalRevenueUsdFromTransactions({
   transactions,
   networkId,
   startTimestamp,
-  endTimestamp,
+  endTimestampExclusive,
 }: {
   transactions: FonbnkTransaction[]
   networkId: NetworkId
   startTimestamp: Date
-  endTimestamp: Date
+  endTimestampExclusive: Date
 }): Promise<number> {
   if (transactions.length === 0) {
     return 0
@@ -95,7 +95,7 @@ export async function getTotalRevenueUsdFromTransactions({
   const tokenPrices = await fetchTokenPrices({
     tokenId,
     startTimestamp,
-    endTimestamp,
+    endTimestampExclusive,
   })
 
   // For each transaction compute the USD contribution and add to the total
@@ -120,11 +120,11 @@ export async function getTotalRevenueUsdFromTransactions({
 export async function calculateRevenue({
   address,
   startTimestamp,
-  endTimestamp,
+  endTimestampExclusive,
 }: {
   address: string
   startTimestamp: Date
-  endTimestamp: Date
+  endTimestampExclusive: Date
 }): Promise<number> {
   if (!isAddress(address)) {
     throw new Error('Invalid address')
@@ -154,7 +154,7 @@ export async function calculateRevenue({
         address,
         payoutWallet,
         startTimestamp,
-        endTimestamp,
+        endTimestampExclusive,
         client,
         networkId: fonbnkNetworkToNetworkId[supportedNetwork],
       })
@@ -162,7 +162,7 @@ export async function calculateRevenue({
         transactions,
         networkId: fonbnkNetworkToNetworkId[supportedNetwork],
         startTimestamp,
-        endTimestamp,
+        endTimestampExclusive,
       })
       totalRevenue += revenue
     }

--- a/scripts/calculateRevenue/protocols/somm/dailySnapshots.test.ts
+++ b/scripts/calculateRevenue/protocols/somm/dailySnapshots.test.ts
@@ -19,7 +19,7 @@ describe('calculateWeightedAveragePrice', () => {
     const avgPrice = calculateWeightedAveragePrice({
       snapshots,
       startTimestamp: new Date('2024-03-01T00:00:00Z'),
-      endTimestamp: new Date('2024-03-03T00:00:00Z'),
+      endTimestampExclusive: new Date('2024-03-03T00:00:00Z'),
     })
 
     expect(avgPrice).toBeCloseTo(105)
@@ -35,7 +35,7 @@ describe('calculateWeightedAveragePrice', () => {
     const avgPrice = calculateWeightedAveragePrice({
       snapshots,
       startTimestamp: new Date('2024-03-01T12:00:00Z'),
-      endTimestamp: new Date('2024-03-02T12:00:00Z'),
+      endTimestampExclusive: new Date('2024-03-02T12:00:00Z'),
     })
 
     expect(avgPrice).toBeCloseTo(105)
@@ -51,7 +51,7 @@ describe('calculateWeightedAveragePrice', () => {
     const avgPrice = calculateWeightedAveragePrice({
       snapshots,
       startTimestamp: new Date('2024-03-01T12:00:00Z'),
-      endTimestamp: new Date('2024-03-03T12:00:00Z'),
+      endTimestampExclusive: new Date('2024-03-03T12:00:00Z'),
     })
 
     expect(avgPrice).toBeCloseTo(110)
@@ -67,7 +67,7 @@ describe('calculateWeightedAveragePrice', () => {
     const avgPrice = calculateWeightedAveragePrice({
       snapshots,
       startTimestamp: new Date('2024-03-01T12:00:00Z'),
-      endTimestamp: new Date('2024-03-03T18:00:00Z'),
+      endTimestampExclusive: new Date('2024-03-03T18:00:00Z'),
     })
 
     expect(avgPrice).toBeCloseTo(111.1111)
@@ -81,7 +81,7 @@ describe('calculateWeightedAveragePrice', () => {
     const avgPrice = calculateWeightedAveragePrice({
       snapshots,
       startTimestamp: new Date('2024-03-01T00:00:00Z'),
-      endTimestamp: new Date('2024-03-01T23:59:59Z'),
+      endTimestampExclusive: new Date('2024-03-01T23:59:59Z'),
     })
 
     expect(avgPrice).toBe(150)
@@ -96,7 +96,7 @@ describe('calculateWeightedAveragePrice', () => {
     const avgPrice = calculateWeightedAveragePrice({
       snapshots,
       startTimestamp: new Date('2024-03-01T12:00:00Z'),
-      endTimestamp: new Date('2024-03-02T12:00:00Z'),
+      endTimestampExclusive: new Date('2024-03-02T12:00:00Z'),
     })
 
     expect(avgPrice).toBeCloseTo((100 + 55) / 2)
@@ -107,12 +107,12 @@ describe('calculateWeightedAveragePrice', () => {
       calculateWeightedAveragePrice({
         snapshots: [],
         startTimestamp: new Date('2024-03-01T00:00:00Z'),
-        endTimestamp: new Date('2024-03-02T00:00:00Z'),
+        endTimestampExclusive: new Date('2024-03-02T00:00:00Z'),
       }),
     ).toThrow('No snapshots provided')
   })
 
-  it('throws an error if startTimestamp is after endTimestamp', () => {
+  it('throws an error if startTimestamp is after endTimestampExclusive', () => {
     const snapshots: DailySnapshot[] = [
       { price_usd: 100, share_price: 1, timestamp: '2024-03-01T00:00:00Z' },
     ] as DailySnapshot[]
@@ -121,7 +121,7 @@ describe('calculateWeightedAveragePrice', () => {
       calculateWeightedAveragePrice({
         snapshots,
         startTimestamp: new Date('2024-03-02T00:00:00Z'),
-        endTimestamp: new Date('2024-03-01T00:00:00Z'),
+        endTimestampExclusive: new Date('2024-03-01T00:00:00Z'),
       }),
     ).toThrow('Invalid timestamps provided')
   })
@@ -148,7 +148,7 @@ describe('getDailySnapshots', () => {
     expect(() =>
       getDailySnapshots({
         startTimestamp: new Date('2024-03-01T00:00:00Z'),
-        endTimestamp: new Date('2024-03-02T00:00:00Z'),
+        endTimestampExclusive: new Date('2024-03-02T00:00:00Z'),
         ...params,
       }),
     ).rejects.toThrow('Start time is before the first snapshot')
@@ -169,7 +169,7 @@ describe('getDailySnapshots', () => {
     expect(() =>
       getDailySnapshots({
         startTimestamp: new Date('2024-03-01T00:00:00Z'),
-        endTimestamp: new Date('2024-03-03T00:00:01Z'),
+        endTimestampExclusive: new Date('2024-03-03T00:00:01Z'),
         ...params,
       }),
     ).rejects.toThrow('End time is after the last snapshot')
@@ -191,7 +191,7 @@ describe('getDailySnapshots', () => {
     expect(() =>
       getDailySnapshots({
         startTimestamp: new Date('2024-03-01T00:00:00Z'),
-        endTimestamp: new Date('2024-03-03T00:00:00Z'),
+        endTimestampExclusive: new Date('2024-03-03T00:00:00Z'),
         ...params,
       }),
     ).rejects.toThrow('Missing snapshots')

--- a/scripts/calculateRevenue/protocols/somm/dailySnapshots.ts
+++ b/scripts/calculateRevenue/protocols/somm/dailySnapshots.ts
@@ -19,18 +19,18 @@ export async function getDailySnapshots({
   networkId,
   vaultAddress,
   startTimestamp,
-  endTimestamp,
+  endTimestampExclusive,
 }: {
   networkId: NetworkId
   vaultAddress: string
   startTimestamp: Date
-  endTimestamp: Date
+  endTimestampExclusive: Date
 }): Promise<DailySnapshot[]> {
   // Subtract 24 hours from the start time to ensure we get the snapshot for the start time
   const startUnixTimestamp = Math.floor(
     (startTimestamp.getTime() - TWENTY_FOUR_HOURS) / 1000,
   )
-  const endUnixTimestamp = Math.floor(endTimestamp.getTime() / 1000)
+  const endUnixTimestamp = Math.floor(endTimestampExclusive.getTime() / 1000)
   const url = `https://api.sommelier.finance/dailyData/${NETWORK_ID_TO_CHAIN_ID[networkId]}/${vaultAddress}/${startUnixTimestamp}/${endUnixTimestamp}`
 
   const response = await fetchWithTimeout(url)
@@ -51,7 +51,7 @@ export async function getDailySnapshots({
   if (startTimestamp.getTime() < firstSnapshotTime) {
     throw new Error('Start time is before the first snapshot')
   }
-  if (endTimestamp.getTime() > lastSnapshotTime + TWENTY_FOUR_HOURS) {
+  if (endTimestampExclusive.getTime() > lastSnapshotTime + TWENTY_FOUR_HOURS) {
     throw new Error('End time is after the last snapshot')
   }
   if (
@@ -71,14 +71,14 @@ export async function getDailySnapshots({
 export function calculateWeightedAveragePrice({
   snapshots,
   startTimestamp,
-  endTimestamp,
+  endTimestampExclusive,
 }: {
   snapshots: DailySnapshot[]
   startTimestamp: Date
-  endTimestamp: Date
+  endTimestampExclusive: Date
 }): number {
   const startTime = startTimestamp.getTime()
-  const endTime = endTimestamp.getTime()
+  const endTime = endTimestampExclusive.getTime()
 
   if (isNaN(startTime) || isNaN(endTime) || startTime > endTime) {
     throw new Error('Invalid timestamps provided')

--- a/scripts/calculateRevenue/protocols/somm/getEvents.test.ts
+++ b/scripts/calculateRevenue/protocols/somm/getEvents.test.ts
@@ -53,7 +53,7 @@ describe('getEvents', () => {
         vaultAddress: '0x1234567890123456789012345678901234567890',
       },
       startTimestamp: new Date('2021-01-01'),
-      endTimestamp: new Date('2021-01-10'),
+      endTimestampExclusive: new Date('2021-01-10'),
     })
     expect(result).toEqual([
       { amount: -5, timestamp: new Date(3 * 100 * 1000) },
@@ -65,14 +65,14 @@ describe('getEvents', () => {
       networkId: NetworkId['arbitrum-one'],
       eventName: 'Deposit',
       startTimestamp: new Date('2021-01-01'),
-      endTimestamp: new Date('2021-01-10'),
+      endTimestampExclusive: new Date('2021-01-10'),
     })
     expect(fetchEvents).toHaveBeenNthCalledWith(2, {
       contract: expect.any(Object),
       networkId: NetworkId['arbitrum-one'],
       eventName: 'Withdraw',
       startTimestamp: new Date('2021-01-01'),
-      endTimestamp: new Date('2021-01-10'),
+      endTimestampExclusive: new Date('2021-01-10'),
     })
     expect(getBlock).toHaveBeenCalledTimes(2)
   })

--- a/scripts/calculateRevenue/protocols/somm/getEvents.ts
+++ b/scripts/calculateRevenue/protocols/somm/getEvents.ts
@@ -18,12 +18,12 @@ export async function getEvents({
   address,
   vaultInfo,
   startTimestamp,
-  endTimestamp,
+  endTimestampExclusive,
 }: {
   address: Address
   vaultInfo: VaultInfo
   startTimestamp: Date
-  endTimestamp: Date
+  endTimestampExclusive: Date
 }) {
   const client = getViemPublicClient(vaultInfo.networkId)
   const vaultContract = getContract({
@@ -41,7 +41,7 @@ export async function getEvents({
       networkId: vaultInfo.networkId,
       eventName: 'Deposit',
       startTimestamp,
-      endTimestamp,
+      endTimestampExclusive,
     })
   ).filter((event) => {
     return isAddressEqual((event.args as { sender: Address }).sender, address)
@@ -63,7 +63,7 @@ export async function getEvents({
       networkId: vaultInfo.networkId,
       eventName: 'Withdraw',
       startTimestamp,
-      endTimestamp,
+      endTimestampExclusive,
     })
   ).filter((event) => {
     return isAddressEqual((event.args as { sender: Address }).sender, address)

--- a/scripts/calculateRevenue/protocols/somm/index.test.ts
+++ b/scripts/calculateRevenue/protocols/somm/index.test.ts
@@ -24,23 +24,23 @@ const vaultInfo = {
 const address = '0x1234567890123456789012345678901234567890'
 
 describe('getTvlProratedPerYear', () => {
-  it('should throw an error if endTimestamp is in the future', async () => {
+  it('should throw an error if endTimestampExclusive is in the future', async () => {
     const startTimestamp = new Date('2021-01-0')
-    const endTimestamp = new Date('2022-01-01')
+    const endTimestampExclusive = new Date('2022-01-01')
     const nowTimestamp = new Date('2021-01-01')
     await expect(
       getTvlProratedPerYear({
         vaultInfo,
         address,
         startTimestamp,
-        endTimestamp,
+        endTimestampExclusive,
         nowTimestamp,
       }),
-    ).rejects.toThrow('Cannot have an endTimestamp in the future')
+    ).rejects.toThrow('Cannot have an endTimestampExclusive in the future')
   })
   it('should return the correct mean TVL', async () => {
     const startTimestamp = new Date('2021-01-05')
-    const endTimestamp = new Date('2021-01-20')
+    const endTimestampExclusive = new Date('2021-01-20')
     const nowTimestamp = new Date('2021-01-30')
     jest.mocked(calculateWeightedAveragePrice).mockReturnValue(2)
     jest.mocked(getEvents).mockResolvedValueOnce([
@@ -52,7 +52,7 @@ describe('getTvlProratedPerYear', () => {
       vaultInfo,
       address,
       startTimestamp,
-      endTimestamp,
+      endTimestampExclusive,
       nowTimestamp,
     })
     // first chuck of time is 5 days with 100 TVL, the current balance. All outside of the range so it isn't counted
@@ -66,8 +66,8 @@ describe('getTvlProratedPerYear', () => {
   })
   it('should return the correct mean TVL when there are multiple events on the same day', async () => {
     const startTimestamp = new Date('2025-01-10T16:14:52+00:00')
-    const endTimestamp = new Date('2025-01-10T20:14:52+00:00')
-    const nowTimestamp = endTimestamp
+    const endTimestampExclusive = new Date('2025-01-10T20:14:52+00:00')
+    const nowTimestamp = endTimestampExclusive
 
     // first chunk of time is 2 hours with 100 TVL, all inside the range so 100 * 2 = 200 TVL hours
     // second chunk of time is 1 hour with 50 TVL, all inside the range so 50 * 1 = 50 TVL hours
@@ -83,7 +83,7 @@ describe('getTvlProratedPerYear', () => {
       vaultInfo,
       address,
       startTimestamp,
-      endTimestamp,
+      endTimestampExclusive,
       nowTimestamp,
     })
     expect(result).toBeCloseTo(0.03767)

--- a/scripts/calculateRevenue/protocols/utils/drome/calculateRevenueDrome.test.ts
+++ b/scripts/calculateRevenue/protocols/utils/drome/calculateRevenueDrome.test.ts
@@ -103,7 +103,7 @@ describe('Aerodrome revenue calculation', () => {
       const result = await calculateRevenueDrome({
         address: 'mockAddress',
         startTimestamp: new Date(),
-        endTimestamp: new Date(),
+        endTimestampExclusive: new Date(),
         supportedLiquidityPoolAddresses:
           AERODROME_SUPPORTED_LIQUIDITY_POOL_ADDRESSES,
         networkId: AERODROME_NETWORK_ID,

--- a/scripts/calculateRevenue/protocols/utils/drome/calculateRevenueDrome.ts
+++ b/scripts/calculateRevenue/protocols/utils/drome/calculateRevenueDrome.ts
@@ -16,12 +16,12 @@ export async function calculateSwapRevenue(swapEvents: SwapEvent[]) {
 
   if (swapEvents.length > 0) {
     const startTimestamp = swapEvents[0].timestamp
-    const endTimestamp = swapEvents[swapEvents.length - 1].timestamp
+    const endTimestampExclusive = swapEvents[swapEvents.length - 1].timestamp
     const tokenId = swapEvents[0].tokenId
     const tokenPrices = await fetchTokenPrices({
       tokenId,
       startTimestamp,
-      endTimestamp,
+      endTimestampExclusive,
     })
     for (const swapEvent of swapEvents) {
       const tokenPriceUsd = getTokenPrice(
@@ -44,13 +44,13 @@ export async function calculateSwapRevenue(swapEvents: SwapEvent[]) {
 export async function calculateRevenueDrome({
   address,
   startTimestamp,
-  endTimestamp,
+  endTimestampExclusive,
   supportedLiquidityPoolAddresses,
   networkId,
 }: {
   address: string
   startTimestamp: Date
-  endTimestamp: Date
+  endTimestampExclusive: Date
   supportedLiquidityPoolAddresses: Address[]
   networkId: NetworkId
 }): Promise<number> {
@@ -61,7 +61,7 @@ export async function calculateRevenueDrome({
       address,
       liquidityPoolAddress,
       startTimestamp,
-      endTimestamp,
+      endTimestampExclusive,
       networkId,
     )
     const swapAmount = await calculateSwapRevenue(swapEvents)

--- a/scripts/calculateRevenue/protocols/utils/drome/getSwapEvents.ts
+++ b/scripts/calculateRevenue/protocols/utils/drome/getSwapEvents.ts
@@ -9,7 +9,7 @@ export async function getSwapEvents(
   address: string,
   liquidityPoolAddress: Address,
   startTimestamp: Date,
-  endTimestamp: Date,
+  endTimestampExclusive: Date,
   networkId: NetworkId,
 ): Promise<SwapEvent[]> {
   const swapContract = await getAerodromeLiquidityPoolContract(
@@ -21,7 +21,7 @@ export async function getSwapEvents(
     networkId: networkId,
     eventName: 'Swap',
     startTimestamp,
-    endTimestamp,
+    endTimestampExclusive,
   })
   const filteredSwapEvents = allSwapEvents.filter(
     (swapEvent) =>

--- a/scripts/calculateRevenue/protocols/utils/events.test.ts
+++ b/scripts/calculateRevenue/protocols/utils/events.test.ts
@@ -54,11 +54,11 @@ describe('On-chain event helpers', () => {
         .reply(200, { height: 20, timestamp: 2000 })
 
       const startTimestamp = new Date(1000000)
-      const endTimestamp = new Date(2000000)
+      const endTimestampExclusive = new Date(2000000)
       const result = await getBlockRange({
         networkId,
         startTimestamp,
-        endTimestamp,
+        endTimestampExclusive,
       })
       expect(result).toEqual({ startBlock: 10, endBlockExclusive: 20 })
     })
@@ -72,11 +72,11 @@ describe('On-chain event helpers', () => {
         .reply(200, { height: 200, timestamp: 2000 })
 
       const startTimestamp = new Date(1005000)
-      const endTimestamp = new Date(2000000)
+      const endTimestampExclusive = new Date(2000000)
       const result = await getBlockRange({
         networkId,
         startTimestamp,
-        endTimestamp,
+        endTimestampExclusive,
       })
       expect(result).toEqual({ startBlock: 101, endBlockExclusive: 200 })
     })
@@ -90,28 +90,28 @@ describe('On-chain event helpers', () => {
         .reply(200, { height: 200, timestamp: 2000 })
 
       const startTimestamp = new Date(1000000)
-      const endTimestamp = new Date(2005000)
+      const endTimestampExclusive = new Date(2005000)
       const result = await getBlockRange({
         networkId,
         startTimestamp,
-        endTimestamp,
+        endTimestampExclusive,
       })
       expect(result).toEqual({ startBlock: 100, endBlockExclusive: 201 })
     })
 
-    it('should throw if startTimestamp is not before endTimestamp', async () => {
+    it('should throw if startTimestamp is not before endTimestampExclusive', async () => {
       const startTimestamp = new Date(2000000)
-      const endTimestamp = new Date(1000000)
+      const endTimestampExclusive = new Date(1000000)
       await expect(
-        getBlockRange({ networkId, startTimestamp, endTimestamp }),
+        getBlockRange({ networkId, startTimestamp, endTimestampExclusive }),
       ).rejects.toThrow('Start timestamp must be before end timestamp.')
     })
 
-    it('should throw if startTimestamp is equal to endTimestamp', async () => {
+    it('should throw if startTimestamp is equal to endTimestampExclusive', async () => {
       const startTimestamp = new Date(1000000)
-      const endTimestamp = new Date(1000000)
+      const endTimestampExclusive = new Date(1000000)
       await expect(
-        getBlockRange({ networkId, startTimestamp, endTimestamp }),
+        getBlockRange({ networkId, startTimestamp, endTimestampExclusive }),
       ).rejects.toThrow('Start timestamp must be before end timestamp.')
     })
 
@@ -121,14 +121,14 @@ describe('On-chain event helpers', () => {
         .reply(200, { height: 9, timestamp: 990 }) // Results in startBlock = 10
 
       nock('https://coins.llama.fi')
-        .get('/block/arbitrum/1001') // For endTimestamp = new Date(1001000)
+        .get('/block/arbitrum/1001') // For endTimestampExclusive = new Date(1001000)
         .reply(200, { height: 9, timestamp: 990 }) // Results in endBlock = 10
 
       const startTimestamp = new Date(1000000)
-      const endTimestamp = new Date(1001000) // endTimestamp > startTimestamp, so first validation passes
+      const endTimestampExclusive = new Date(1001000) // endTimestampExclusive > startTimestamp, so first validation passes
 
       await expect(
-        getBlockRange({ networkId, startTimestamp, endTimestamp }),
+        getBlockRange({ networkId, startTimestamp, endTimestampExclusive }),
       ).rejects.toThrow(
         `Calculated startBlock (height: 10) is not strictly less than calculated endBlockExclusive (height: 10).`,
       )
@@ -159,13 +159,13 @@ describe('On-chain event helpers', () => {
         .reply(200, { height: 15000, timestamp: 1000 })
 
       const startTimestamp = new Date(0)
-      const endTimestamp = new Date(1000)
+      const endTimestampExclusive = new Date(1000)
       const result = await fetchEvents({
         contract: mockContract,
         eventName: 'Swap',
         networkId,
         startTimestamp,
-        endTimestamp,
+        endTimestampExclusive,
       })
 
       expect(mockGetContractEvents).toHaveBeenCalledTimes(2)
@@ -201,11 +201,11 @@ describe('On-chain event helpers', () => {
         .get('/block/arbitrum/1000') // For startTimestamp = new Date(1000000)
         .reply(200, { height: 9, timestamp: 990 }) // Results in startBlock = 10
       nock('https://coins.llama.fi')
-        .get('/block/arbitrum/1001') // For endTimestamp = new Date(1001000)
+        .get('/block/arbitrum/1001') // For endTimestampExclusive = new Date(1001000)
         .reply(200, { height: 9, timestamp: 990 }) // Results in endBlock = 10
 
       const startTimestamp = new Date(1000000)
-      const endTimestamp = new Date(1001000) // startTimestamp < endTimestamp is true
+      const endTimestampExclusive = new Date(1001000) // startTimestamp < endTimestampExclusive is true
 
       // We expect fetchEvents to propagate the error thrown by getBlockRange.
       await expect(
@@ -214,7 +214,7 @@ describe('On-chain event helpers', () => {
           eventName: 'Swap',
           networkId,
           startTimestamp: startTimestamp,
-          endTimestamp: endTimestamp,
+          endTimestampExclusive: endTimestampExclusive,
         }),
       ).rejects.toThrow(
         `Calculated startBlock (height: 10) is not strictly less than calculated endBlockExclusive (height: 10).`,

--- a/scripts/calculateRevenue/protocols/utils/events.ts
+++ b/scripts/calculateRevenue/protocols/utils/events.ts
@@ -73,34 +73,34 @@ async function getFirstBlockAtOrAfterTimestamp(
 
 /**
  * Calculates the start and end block numbers for a given time range.
- * The time range is defined as [startTimestamp, endTimestamp),
- * meaning it's inclusive of the startTimestamp and exclusive of the endTimestamp.
+ * The time range is defined as [startTimestamp, endTimestampExclusive),
+ * meaning it's inclusive of the startTimestamp and exclusive of the endTimestampExclusive.
  *
  * @param networkId The ID of the network.
  * @param startTimestamp The inclusive start date of the time range.
- * @param endTimestamp The exclusive end date of the time range.
+ * @param endTimestampExclusive The exclusive end date of the time range.
  * @returns A promise that resolves to an object containing:
  *    `startBlock`: The first block whose timestamp is >= startTimestamp (inclusive).
- *    `endBlockExclusive`: The first block whose timestamp is >= endTimestamp. This block itself
+ *    `endBlockExclusive`: The first block whose timestamp is >= endTimestampExclusive. This block itself
  *                is *exclusive* from the desired range. When used in loops like
  *                `for (let i = startBlock; i < endBlockExclusive; i++)`, or as an exclusive
  *                upper bound in queries, it correctly defines the desired time window.
- * @throws Will throw an error if startTimestamp is not before endTimestamp, or if a valid
+ * @throws Will throw an error if startTimestamp is not before endTimestampExclusive, or if a valid
  *         block range cannot be determined (e.g., startBlock ends up >= endBlockExclusive).
  */
 export async function getBlockRange({
   networkId,
   startTimestamp,
-  endTimestamp,
+  endTimestampExclusive,
 }: {
   networkId: NetworkId
   startTimestamp: Date // inclusive
-  endTimestamp: Date // exclusive
+  endTimestampExclusive: Date // exclusive
 }): Promise<{
   startBlock: number // inclusive
   endBlockExclusive: number
 }> {
-  if (startTimestamp.getTime() >= endTimestamp.getTime()) {
+  if (startTimestamp.getTime() >= endTimestampExclusive.getTime()) {
     throw new Error('Start timestamp must be before end timestamp.')
   }
 
@@ -109,21 +109,21 @@ export async function getBlockRange({
     // This is the first block whose timestamp is greater than or equal to the startTimestamp.
     getFirstBlockAtOrAfterTimestamp(networkId, startTimestamp),
     // Determine the exclusive endBlock:
-    // This is the first block whose timestamp is greater than or equal to the endTimestamp.
+    // This is the first block whose timestamp is greater than or equal to the endTimestampExclusive.
     // Using this block's height as `endBlockExclusive` means that loops iterating up to `endBlockExclusive - 1`
     // will process all blocks strictly before this `endBlockExclusive`.
-    // Thus, the last processed block will have a timestamp < endTimestamp.
-    getFirstBlockAtOrAfterTimestamp(networkId, endTimestamp),
+    // Thus, the last processed block will have a timestamp < endTimestampExclusive.
+    getFirstBlockAtOrAfterTimestamp(networkId, endTimestampExclusive),
   ])
 
   // Validate the calculated block range.
   // The startBlock must be strictly less than the endBlockExclusive for a valid, non-empty range.
-  // If startBlock == endBlockExclusive, the range is empty (e.g., startTimestamp and endTimestamp map to the same block for their >= condition).
-  // If startBlock > endBlockExclusive, it implies an issue, possibly with startTimestamp mapping to a block after endTimestamp's mapped block,
+  // If startBlock == endBlockExclusive, the range is empty (e.g., startTimestamp and endTimestampExclusive map to the same block for their >= condition).
+  // If startBlock > endBlockExclusive, it implies an issue, possibly with startTimestamp mapping to a block after endTimestampExclusive's mapped block,
   // though the initial timestamp check should largely prevent this specific sequence.
   if (startBlock >= endBlockExclusive) {
     throw new Error(
-      `Calculated startBlock (height: ${startBlock}) is not strictly less than calculated endBlockExclusive (height: ${endBlockExclusive}). This results in an empty or invalid range. Ensure startTimestamp and endTimestamp define a valid, non-empty interval. It's possible the startTimestamp maps to a block that is at or after the endTimestamp's mapped block.`,
+      `Calculated startBlock (height: ${startBlock}) is not strictly less than calculated endBlockExclusive (height: ${endBlockExclusive}). This results in an empty or invalid range. Ensure startTimestamp and endTimestampExclusive define a valid, non-empty interval. It's possible the startTimestamp maps to a block that is at or after the endTimestampExclusive's mapped block.`,
     )
   }
 
@@ -138,7 +138,7 @@ export async function getBlockRange({
  * @param {NetworkId} params.networkId - The network ID where the contract is deployed.
  * @param {string} params.eventName - The name of the event to fetch.
  * @param {Date} params.startTimestamp - The start timestamp for the event search.
- * @param {Date} params.endTimestamp - The end timestamp for the event search.
+ * @param {Date} params.endTimestampExclusive - The end timestamp for the event search.
  * @returns {Promise<Log[]>} A promise that resolves to an array of event logs.
  */
 async function _fetchEvents({
@@ -146,20 +146,20 @@ async function _fetchEvents({
   networkId,
   eventName,
   startTimestamp,
-  endTimestamp,
+  endTimestampExclusive,
 }: {
   contract: GetContractReturnType
   eventName: string
   networkId: NetworkId
   startTimestamp: Date
-  endTimestamp: Date
+  endTimestampExclusive: Date
 }) {
   const client = getViemPublicClient(networkId)
 
   const { startBlock, endBlockExclusive } = await getBlockRange({
     networkId,
     startTimestamp,
-    endTimestamp,
+    endTimestampExclusive,
   })
   const blocksPerQuery = 10000
   let currentBlock = startBlock

--- a/scripts/calculateRevenue/protocols/utils/tokenPrices.ts
+++ b/scripts/calculateRevenue/protocols/utils/tokenPrices.ts
@@ -11,16 +11,16 @@ const GET_TOKENS_PRICE_HISTORY_API_URL =
 async function _fetchTokenPrices({
   tokenId,
   startTimestamp,
-  endTimestamp,
+  endTimestampExclusive,
 }: {
   tokenId: string
   startTimestamp: Date
-  endTimestamp: Date
+  endTimestampExclusive: Date
 }): Promise<TokenPriceData[]> {
   const queryParams = new URLSearchParams({
     tokenId,
     startTimestamp: startTimestamp.getTime().toString(),
-    endTimestamp: endTimestamp.getTime().toString(),
+    endTimestamp: endTimestampExclusive.getTime().toString(),
   })
   const response = await fetchWithTimeout(
     `${GET_TOKENS_PRICE_HISTORY_API_URL}?${queryParams}`,

--- a/scripts/calculateRevenue/protocols/velodrome/index.ts
+++ b/scripts/calculateRevenue/protocols/velodrome/index.ts
@@ -7,16 +7,16 @@ import { calculateRevenueDrome } from '../utils/drome/calculateRevenueDrome'
 export async function calculateRevenue({
   address,
   startTimestamp,
-  endTimestamp,
+  endTimestampExclusive,
 }: {
   address: string
   startTimestamp: Date
-  endTimestamp: Date
+  endTimestampExclusive: Date
 }): Promise<number> {
   return calculateRevenueDrome({
     address,
     startTimestamp,
-    endTimestamp,
+    endTimestampExclusive,
     supportedLiquidityPoolAddresses:
       VELODROME_SUPPORTED_LIQUIDITY_POOL_ADDRESSES,
     networkId: VELODROME_NETWORK_ID,

--- a/scripts/calculateRewards/celoPG.ts
+++ b/scripts/calculateRewards/celoPG.ts
@@ -79,11 +79,11 @@ interface KpiRow {
 
 async function main(args: ReturnType<typeof parseArgs>) {
   const startTimestamp = new Date(args['start-timestamp'])
-  const endTimestamp = new Date(args['end-timestamp'])
+  const endTimestampExclusive = new Date(args['end-timestamp'])
 
   const folderPath = `rewards/celo-pg/${toPeriodFolderName({
     startTimestamp,
-    endTimestamp,
+    endTimestampExclusive,
   })}`
   const inputPath = `${folderPath}/revenue.csv`
   const outputPath = `${folderPath}/safe-transactions.json`
@@ -105,7 +105,7 @@ async function main(args: ReturnType<typeof parseArgs>) {
     rewardPoolAddress: REWARD_POOL_ADDRESS,
     rewards,
     startTimestamp,
-    endTimestamp,
+    endTimestampExclusive,
   })
 }
 

--- a/scripts/calculateRewards/divviIntegration.ts
+++ b/scripts/calculateRewards/divviIntegration.ts
@@ -68,7 +68,7 @@ async function getArgs() {
     output: argv['output-file'] ?? 'divvi-integrator-rewards.csv',
     safeTransactionsFile: argv['safe-transactions-file'],
     startTimestamp: new Date(argv['start-timestamp']),
-    endTimestamp: new Date(argv['end-timestamp']),
+    endTimestampExclusive: new Date(argv['end-timestamp']),
   }
 }
 
@@ -108,11 +108,11 @@ function removeDuplicates<T>(arr: T[]): T[] {
 async function getDivviIntegrators({
   rewardPoolContractAddress,
   startTimestamp,
-  endTimestamp,
+  endTimestampExclusive,
 }: {
   rewardPoolContractAddress: string
   startTimestamp: Date
-  endTimestamp: Date
+  endTimestampExclusive: Date
 }): Promise<Address[]> {
   const consumersThatHaveIntegrated: Address[] = []
   const consumersThatHaveReceivedRewards = new Set<Address>()
@@ -126,7 +126,7 @@ async function getDivviIntegrators({
   const { startBlock, endBlockExclusive } = await getBlockRange({
     networkId: NetworkId['op-mainnet'],
     startTimestamp,
-    endTimestamp,
+    endTimestampExclusive,
   })
 
   const queryForIntegrators = {
@@ -252,7 +252,7 @@ async function main() {
   const integratorAddresses: Address[] = await getDivviIntegrators({
     rewardPoolContractAddress: DIVVI_REWARD_POOL_ADDRESS,
     startTimestamp: args.startTimestamp,
-    endTimestamp: args.endTimestamp,
+    endTimestampExclusive: args.endTimestampExclusive,
   })
 
   writeFileSync(
@@ -272,7 +272,7 @@ async function main() {
         rewardAmount: DIVVI_REWARD_AMOUNT.toString(),
       })),
       startTimestamp: args.startTimestamp,
-      endTimestamp: args.endTimestamp,
+      endTimestampExclusive: args.endTimestampExclusive,
     })
   }
 }

--- a/scripts/calculateRewards/e2eTestRewards.ts
+++ b/scripts/calculateRewards/e2eTestRewards.ts
@@ -85,7 +85,7 @@ async function main(args: ReturnType<typeof parseArgs>) {
     rewardPoolAddress: REWARD_POOL_ADDRESS,
     rewards,
     startTimestamp: new Date(args['start-timestamp']),
-    endTimestamp: new Date(args['end-timestamp']),
+    endTimestampExclusive: new Date(args['end-timestamp']),
   })
 }
 

--- a/scripts/calculateRewards/proofOfImpact.test.ts
+++ b/scripts/calculateRewards/proofOfImpact.test.ts
@@ -6,9 +6,11 @@ import BigNumber from 'bignumber.js'
 
 describe('calculateRewardsProofOfImpact', () => {
   const startTimestamp = new Date('2025-05-08')
-  const endTimestamp = new Date('2025-05-15')
+  const endTimestampExclusive = new Date('2025-05-15')
   const expectedTotalRewardsForPeriod = _rewardsPerMillisecond.times(
-    new BigNumber(endTimestamp.getTime()).minus(startTimestamp.getTime()),
+    new BigNumber(endTimestampExclusive.getTime()).minus(
+      startTimestamp.getTime(),
+    ),
   )
 
   it('should calculate rewards proportionally based on revenue', () => {
@@ -33,7 +35,7 @@ describe('calculateRewardsProofOfImpact', () => {
     const rewards = calculateRewardsProofOfImpact({
       kpiData,
       startTimestamp,
-      endTimestamp,
+      endTimestampExclusive,
     })
 
     expect(rewards).toEqual([
@@ -58,7 +60,7 @@ describe('calculateRewardsProofOfImpact', () => {
     const rewards = calculateRewardsProofOfImpact({
       kpiData: [],
       startTimestamp,
-      endTimestamp,
+      endTimestampExclusive,
     })
 
     expect(rewards).toHaveLength(0)
@@ -76,7 +78,7 @@ describe('calculateRewardsProofOfImpact', () => {
     const rewards = calculateRewardsProofOfImpact({
       kpiData,
       startTimestamp,
-      endTimestamp,
+      endTimestampExclusive,
     })
 
     expect(rewards).toEqual([

--- a/scripts/calculateRewards/proofOfImpact.ts
+++ b/scripts/calculateRewards/proofOfImpact.ts
@@ -10,12 +10,12 @@ import { toPeriodFolderName } from '../utils/dateFormatting'
 // May 8 2025 12:00:00 AM UTC
 const proofOfImpactStartTimestamp = '1746687600000'
 // May 29 2025 12:00:00 AM UTC
-const proofOfImpactEndTimestamp = '1748502000000'
+const proofOfImpactendTimestampExclusive = '1748502000000'
 const totalRewards = parseEther('14839')
 const REWARD_POOL_ADDRESS = '0xE2bEdafB063e0B7f12607ebcf4636e2690A427a3' // on Celo mainnet
 
 const rewardsPerMillisecond = new BigNumber(totalRewards).div(
-  new BigNumber(proofOfImpactEndTimestamp).minus(
+  new BigNumber(proofOfImpactendTimestampExclusive).minus(
     new BigNumber(proofOfImpactStartTimestamp),
   ),
 )
@@ -25,13 +25,13 @@ export const _rewardsPerMillisecond = rewardsPerMillisecond // for testing
 export function calculateRewardsProofOfImpact({
   kpiData,
   startTimestamp,
-  endTimestamp,
+  endTimestampExclusive,
 }: {
   kpiData: KpiRow[]
   startTimestamp: Date
-  endTimestamp: Date
+  endTimestampExclusive: Date
 }) {
-  const timeDiff = new BigNumber(endTimestamp.getTime()).minus(
+  const timeDiff = new BigNumber(endTimestampExclusive.getTime()).minus(
     new BigNumber(startTimestamp.getTime()),
   )
   const totalRewardsForPeriod = timeDiff.times(rewardsPerMillisecond)
@@ -98,11 +98,11 @@ interface KpiRow {
 
 async function main(args: ReturnType<typeof parseArgs>) {
   const startTimestamp = new Date(args['start-timestamp'])
-  const endTimestamp = new Date(args['end-timestamp'])
+  const endTimestampExclusive = new Date(args['end-timestamp'])
 
   const folderPath = `rewards/celo-transactions/${toPeriodFolderName({
     startTimestamp,
-    endTimestamp,
+    endTimestampExclusive,
   })}`
   const inputPath = `${folderPath}/revenue.csv`
   const outputPath = `${folderPath}/safe-transactions.json`
@@ -116,7 +116,7 @@ async function main(args: ReturnType<typeof parseArgs>) {
   const rewards = calculateRewardsProofOfImpact({
     kpiData,
     startTimestamp,
-    endTimestamp,
+    endTimestampExclusive,
   })
 
   console.log(
@@ -133,7 +133,7 @@ async function main(args: ReturnType<typeof parseArgs>) {
     rewardPoolAddress: REWARD_POOL_ADDRESS,
     rewards,
     startTimestamp,
-    endTimestamp,
+    endTimestampExclusive,
   })
 }
 

--- a/scripts/fetchReferrals.ts
+++ b/scripts/fetchReferrals.ts
@@ -49,7 +49,7 @@ async function getArgs() {
     useStaging: argv['use-staging'],
     builderAllowList: argv['builder-allowlist-file'],
     startTimestamp: argv['start-timestamp'],
-    endTimestamp: argv['end-timestamp'],
+    endTimestampExclusive: argv['end-timestamp'],
   }
 }
 
@@ -81,7 +81,7 @@ async function main() {
 
   const outputDir = `rewards/${args.protocol}/${toPeriodFolderName({
     startTimestamp: new Date(args.startTimestamp),
-    endTimestamp: new Date(args.endTimestamp),
+    endTimestampExclusive: new Date(args.endTimestampExclusive),
   })}`
   const outputFile = `${outputDir}/referrals.csv`
 

--- a/scripts/protocolFilters/somm.ts
+++ b/scripts/protocolFilters/somm.ts
@@ -31,7 +31,7 @@ export async function filter(event: ReferralEvent): Promise<boolean> {
       address,
       vaultInfo,
       startTimestamp: eventDate,
-      endTimestamp: nowDate,
+      endTimestampExclusive: nowDate,
     })
     numTvlEvents += tvlEvents.length
     const tvlAtReferral =

--- a/scripts/types.ts
+++ b/scripts/types.ts
@@ -40,7 +40,7 @@ export interface TokenPriceData {
 export type CalculateRevenueFn = (params: {
   address: string
   startTimestamp: Date
-  endTimestamp: Date
+  endTimestampExclusive: Date
 }) => Promise<number>
 
 export interface ReferralEvent {

--- a/scripts/utils/createSafeTransactionsBatch.test.ts
+++ b/scripts/utils/createSafeTransactionsBatch.test.ts
@@ -26,7 +26,7 @@ describe('createAddRewardSafeTransactionJSON', () => {
     },
   ]
   const mockStartTimestamp = new Date('2023-03-01T00:00:00Z')
-  const mockEndTimestamp = new Date('2023-04-01T00:00:00Z')
+  const mockendTimestampExclusive = new Date('2023-04-01T00:00:00Z')
 
   beforeEach(() => {
     jest.clearAllMocks()
@@ -38,7 +38,7 @@ describe('createAddRewardSafeTransactionJSON', () => {
       rewardPoolAddress: mockRewardPoolAddress,
       rewards: mockRewards,
       startTimestamp: mockStartTimestamp,
-      endTimestamp: mockEndTimestamp,
+      endTimestampExclusive: mockendTimestampExclusive,
     })
 
     // Verify directory creation
@@ -96,7 +96,7 @@ describe('createAddRewardSafeTransactionJSON', () => {
       rewardPoolAddress: mockRewardPoolAddress,
       rewards: [],
       startTimestamp: mockStartTimestamp,
-      endTimestamp: mockEndTimestamp,
+      endTimestampExclusive: mockendTimestampExclusive,
     })
 
     // Verify directory creation

--- a/scripts/utils/createSafeTransactionsBatch.ts
+++ b/scripts/utils/createSafeTransactionsBatch.ts
@@ -6,7 +6,7 @@ export const createAddRewardSafeTransactionJSON = ({
   rewardPoolAddress,
   rewards,
   startTimestamp,
-  endTimestamp,
+  endTimestampExclusive,
 }: {
   filePath: string
   rewardPoolAddress: string
@@ -15,7 +15,7 @@ export const createAddRewardSafeTransactionJSON = ({
     rewardAmount: string // in smallest unit of reward token
   }[]
   startTimestamp: Date
-  endTimestamp: Date
+  endTimestampExclusive: Date
 }) => {
   const users: string[] = []
   const amounts: string[] = []
@@ -58,7 +58,7 @@ export const createAddRewardSafeTransactionJSON = ({
           amounts: `[${amounts.join(', ')}]`,
           // Convert timestamps to seconds
           rewardFunctionArgs: `[${BigInt(startTimestamp.getTime() / 1000)}, ${BigInt(
-            endTimestamp.getTime() / 1000,
+            endTimestampExclusive.getTime() / 1000,
           )}]`,
         },
       },

--- a/scripts/utils/dateFormatting.ts
+++ b/scripts/utils/dateFormatting.ts
@@ -1,10 +1,10 @@
 // Returns a folder name in the format of YYYY-MM-DDTHH-MM-SSZ_YYYY-MM-DDTHH-MM-SSZ
 export function toPeriodFolderName({
   startTimestamp,
-  endTimestamp,
+  endTimestampExclusive,
 }: {
   startTimestamp: Date
-  endTimestamp: Date
+  endTimestampExclusive: Date
 }) {
-  return `${startTimestamp.toISOString()}_${endTimestamp.toISOString()}`
+  return `${startTimestamp.toISOString()}_${endTimestampExclusive.toISOString()}`
 }


### PR DESCRIPTION
For maximum clarity given the different behaviors of the underlying APIs.

Proposed in https://github.com/divvi-xyz/divvi-protocol-v0/pull/141#discussion_r2088464522

This was done using a global replace, and checked manually that it didn't have unexpected effects.
This should not alter any behavior.

Part of ENG-365