### PR TITLE
fix: referral buffer time incorrect conversion

### DIFF
--- a/scripts/calculateRevenue.ts
+++ b/scripts/calculateRevenue.ts
@@ -8,7 +8,7 @@ import { toPeriodFolderName } from './utils/dateFormatting'
 import { dirname } from 'path'
 
 // Buffer to account for time it takes for a referral to be registered, since the referral transaction is made first and the referral registration happens on a schedule
-const REFERRAL_TIME_BUFFER_IN_SECONDS = 30 * 60 // 30 minutes
+const REFERRAL_TIME_BUFFER_IN_MILLISECONDS = 30 * 60 * 1000 // 30 minutes
 
 async function main(args: ReturnType<typeof parseArgs>) {
   const startTimestamp = new Date(args['start-timestamp'])
@@ -41,12 +41,12 @@ async function main(args: ReturnType<typeof parseArgs>) {
       `Calculating revenue for ${userAddress} (${i + 1}/${eligibleUsers.length})`,
     )
 
-    const referralTimestamp = new Date(
-      timestamp - REFERRAL_TIME_BUFFER_IN_SECONDS,
-    )
-    if (referralTimestamp.getTime() > endTimestamp.getTime()) {
+    const referralTimestamp =
+      new Date(timestamp).getTime() - REFERRAL_TIME_BUFFER_IN_MILLISECONDS
+
+    if (referralTimestamp > endTimestamp.getTime()) {
       console.log(
-        `Referral date is after end date, skipping ${userAddress} (referral date: ${new Date(timestamp).toISOString()})`,
+        `Referral date is after end date, skipping ${userAddress} (referral registration tx date: ${timestamp})`,
       )
       continue
     }
@@ -55,8 +55,8 @@ async function main(args: ReturnType<typeof parseArgs>) {
       address: userAddress,
       // if the referral happened after the start of the period, only calculate revenue from the referral block onwards so that we exclude user activity before the referral
       startTimestamp:
-        referralTimestamp.getTime() > startTimestamp.getTime()
-          ? referralTimestamp
+        referralTimestamp > startTimestamp.getTime()
+          ? new Date(referralTimestamp)
           : startTimestamp,
       endTimestamp,
     })

--- a/scripts/calculateRevenue.ts
+++ b/scripts/calculateRevenue.ts
@@ -44,7 +44,6 @@ async function main(args: ReturnType<typeof parseArgs>) {
     const referralTimestamp = new Date(
       Date.parse(timestamp) - REFERRAL_TIME_BUFFER_IN_MS,
     )
-    console.log('referralTimestamp', referralTimestamp)
 
     if (referralTimestamp.getTime() > endTimestampExclusive.getTime()) {
       // this shouldn't happen if we only fetch and pass in referrals up to endTimestampExclusive

--- a/scripts/calculateRevenue.ts
+++ b/scripts/calculateRevenue.ts
@@ -45,7 +45,7 @@ async function main(args: ReturnType<typeof parseArgs>) {
       new Date(timestamp).getTime() - REFERRAL_TIME_BUFFER_IN_MS
     if (referralTimestamp > endTimestamp.getTime()) {
       console.log(
-        `Referral date is after end date, skipping ${userAddress} (referral date: ${timestamp})`,
+        `Referral date is after end date, skipping ${userAddress} (registration tx date: ${timestamp})`,
       )
       continue
     }

--- a/scripts/calculateRevenue.ts
+++ b/scripts/calculateRevenue.ts
@@ -41,9 +41,12 @@ async function main(args: ReturnType<typeof parseArgs>) {
       `Calculating revenue for ${userAddress} (${i + 1}/${eligibleUsers.length})`,
     )
 
-    const referralTimestamp =
-      new Date(timestamp).getTime() - REFERRAL_TIME_BUFFER_IN_MS
-    if (referralTimestamp > endTimestampExclusive.getTime()) {
+    const referralTimestamp = new Date(
+      Date.parse(timestamp) - REFERRAL_TIME_BUFFER_IN_MS,
+    )
+    console.log('referralTimestamp', referralTimestamp)
+
+    if (referralTimestamp.getTime() > endTimestampExclusive.getTime()) {
       // this shouldn't happen if we only fetch and pass in referrals up to endTimestampExclusive
       console.log(
         `Referral date is after end date, skipping ${userAddress} (registration tx date: ${timestamp})`,
@@ -55,8 +58,8 @@ async function main(args: ReturnType<typeof parseArgs>) {
       address: userAddress,
       // if the referral happened after the start of the period, only calculate revenue from the referral block onwards so that we exclude user activity before the referral
       startTimestamp:
-        referralTimestamp > startTimestamp.getTime()
-          ? new Date(referralTimestamp)
+        referralTimestamp.getTime() > startTimestamp.getTime()
+          ? referralTimestamp
           : startTimestamp,
       endTimestampExclusive,
     })

--- a/scripts/calculateRevenue.ts
+++ b/scripts/calculateRevenue.ts
@@ -44,6 +44,7 @@ async function main(args: ReturnType<typeof parseArgs>) {
     const referralTimestamp =
       new Date(timestamp).getTime() - REFERRAL_TIME_BUFFER_IN_MS
     if (referralTimestamp > endTimestampExclusive.getTime()) {
+      // this shouldn't happen if we only fetch and pass in referrals up to endTimestampExclusive
       console.log(
         `Referral date is after end date, skipping ${userAddress} (registration tx date: ${timestamp})`,
       )

--- a/scripts/calculateRevenue.ts
+++ b/scripts/calculateRevenue.ts
@@ -7,9 +7,6 @@ import { protocols } from './types'
 import { toPeriodFolderName } from './utils/dateFormatting'
 import { dirname } from 'path'
 
-// Buffer to account for time it takes for a referral to be registered, since the referral transaction is made first and the referral registration happens on a schedule
-const REFERRAL_TIME_BUFFER_IN_MILLISECONDS = 30 * 60 * 1000 // 30 minutes
-
 async function main(args: ReturnType<typeof parseArgs>) {
   const startTimestamp = new Date(args['start-timestamp'])
   const endTimestamp = new Date(args['end-timestamp'])
@@ -41,12 +38,10 @@ async function main(args: ReturnType<typeof parseArgs>) {
       `Calculating revenue for ${userAddress} (${i + 1}/${eligibleUsers.length})`,
     )
 
-    const referralTimestamp =
-      new Date(timestamp).getTime() - REFERRAL_TIME_BUFFER_IN_MILLISECONDS
-
-    if (referralTimestamp > endTimestamp.getTime()) {
+    const referralTimestamp = new Date(timestamp)
+    if (referralTimestamp.getTime() > endTimestamp.getTime()) {
       console.log(
-        `Referral date is after end date, skipping ${userAddress} (referral registration tx date: ${timestamp})`,
+        `Referral date is after end date, skipping ${userAddress} (registration tx date: ${timestamp})`,
       )
       continue
     }
@@ -55,8 +50,8 @@ async function main(args: ReturnType<typeof parseArgs>) {
       address: userAddress,
       // if the referral happened after the start of the period, only calculate revenue from the referral block onwards so that we exclude user activity before the referral
       startTimestamp:
-        referralTimestamp > startTimestamp.getTime()
-          ? new Date(referralTimestamp)
+        referralTimestamp.getTime() > startTimestamp.getTime()
+          ? referralTimestamp
           : startTimestamp,
       endTimestamp,
     })

--- a/scripts/fetchReferrals.ts
+++ b/scripts/fetchReferrals.ts
@@ -56,10 +56,12 @@ async function getArgs() {
 async function main() {
   const args = await getArgs()
 
+  const endTimestamp = new Date(args.endTimestamp)
   const referralEvents = await fetchReferralEvents(
     args.protocol,
     undefined,
     args.useStaging,
+    endTimestamp,
   )
   const uniqueEvents = removeDuplicates(referralEvents)
   const builderAllowList = args.builderAllowList
@@ -76,7 +78,7 @@ async function main() {
   const outputEvents = filteredEvents.map((event) => ({
     referrerId: event.referrerId,
     userAddress: event.userAddress,
-    timestamp: event.timestamp,
+    timestamp: new Date(event.timestamp * 1000).toISOString(),
   }))
 
   const outputDir = `rewards/${args.protocol}/${toPeriodFolderName({

--- a/scripts/fetchReferrals.ts
+++ b/scripts/fetchReferrals.ts
@@ -56,12 +56,10 @@ async function getArgs() {
 async function main() {
   const args = await getArgs()
 
-  const endTimestamp = new Date(args.endTimestamp)
   const referralEvents = await fetchReferralEvents(
     args.protocol,
     undefined,
     args.useStaging,
-    endTimestamp,
   )
   const uniqueEvents = removeDuplicates(referralEvents)
   const builderAllowList = args.builderAllowList
@@ -78,7 +76,7 @@ async function main() {
   const outputEvents = filteredEvents.map((event) => ({
     referrerId: event.referrerId,
     userAddress: event.userAddress,
-    timestamp: new Date(event.timestamp * 1000).toISOString(),
+    timestamp: event.timestamp,
   }))
 
   const outputDir = `rewards/${args.protocol}/${toPeriodFolderName({


### PR DESCRIPTION
A bug snuck through where we were creating a date with a timestamp in seconds, when it expects milliseconds. This caused the calculateRevenue script to calculate starting from the unix epoch instead of the reward period specified.