### PR TITLE
refactor: print protocol name in calculateKpi logs

### DIFF
--- a/scripts/calculateKpi.test.ts
+++ b/scripts/calculateKpi.test.ts
@@ -138,7 +138,7 @@ describe('_calculateKpiBatch', () => {
     expect(results).toHaveLength(0)
   })
 
-  it('should handle handler errors gracefully', async () => {
+  it('should fail the whole function if there is an error for any user', async () => {
     mockHandler.mockImplementation(async ({ address }) => {
       if (address === '0x123') {
         throw new Error('Handler error')

--- a/scripts/calculateKpi.test.ts
+++ b/scripts/calculateKpi.test.ts
@@ -1,17 +1,28 @@
 import { _calculateKpiBatch } from './calculateKpi'
 
+const mockHandler = jest.fn()
 jest.mock('./calculateKpi/protocols', () => ({
   __esModule: true,
-  default: {},
+  default: {
+    'celo-transactions': (...args: unknown[]) => mockHandler(...args),
+  },
 }))
 
 describe('_calculateKpiBatch', () => {
-  const mockHandler = jest.fn().mockImplementation(async ({ address }) => {
+  mockHandler.mockImplementation(async ({ address }) => {
     return address === '0x123' ? 100 : 50
   })
 
   const startTimestamp = new Date('2024-01-01T00:00:00Z')
   const endTimestampExclusive = new Date('2024-01-31T23:59:59Z')
+  const defaultArgs = {
+    eligibleUsers: [],
+    handler: mockHandler,
+    batchSize: 2,
+    startTimestamp,
+    endTimestampExclusive,
+    protocol: 'celo-transactions' as const,
+  }
 
   beforeEach(() => {
     jest.clearAllMocks()
@@ -37,11 +48,9 @@ describe('_calculateKpiBatch', () => {
     ]
 
     const results = await _calculateKpiBatch({
+      ...defaultArgs,
       eligibleUsers,
-      handler: mockHandler,
       batchSize: 2, // less than the number of eligible users
-      startTimestamp,
-      endTimestampExclusive,
     })
 
     expect(results).toEqual([
@@ -67,11 +76,8 @@ describe('_calculateKpiBatch', () => {
     ]
 
     const results = await _calculateKpiBatch({
+      ...defaultArgs,
       eligibleUsers,
-      handler: mockHandler,
-      batchSize: 2,
-      startTimestamp,
-      endTimestampExclusive,
     })
 
     expect(results).toEqual([
@@ -92,11 +98,8 @@ describe('_calculateKpiBatch', () => {
     ]
 
     await _calculateKpiBatch({
+      ...defaultArgs,
       eligibleUsers,
-      handler: mockHandler,
-      batchSize: 2,
-      startTimestamp,
-      endTimestampExclusive,
     })
     expect(mockHandler).toHaveBeenCalledWith({
       address: '0x123',
@@ -116,11 +119,8 @@ describe('_calculateKpiBatch', () => {
     ]
 
     await _calculateKpiBatch({
+      ...defaultArgs,
       eligibleUsers,
-      handler: mockHandler,
-      batchSize: 2,
-      startTimestamp,
-      endTimestampExclusive,
     })
     expect(mockHandler).toHaveBeenCalledWith({
       address: '0x123',
@@ -131,17 +131,20 @@ describe('_calculateKpiBatch', () => {
 
   it('should handle empty user list', async () => {
     const results = await _calculateKpiBatch({
+      ...defaultArgs,
       eligibleUsers: [],
-      handler: mockHandler,
-      batchSize: 2,
-      startTimestamp,
-      endTimestampExclusive,
     })
 
     expect(results).toHaveLength(0)
   })
 
   it('should handle handler errors gracefully', async () => {
+    mockHandler.mockImplementation(async ({ address }) => {
+      if (address === '0x123') {
+        throw new Error('Handler error')
+      }
+      return 100
+    })
     const eligibleUsers = [
       {
         referrerId: 'ref1',
@@ -157,16 +160,8 @@ describe('_calculateKpiBatch', () => {
 
     await expect(
       _calculateKpiBatch({
+        ...defaultArgs,
         eligibleUsers,
-        handler: async ({ address }) => {
-          if (address === '0x123') {
-            throw new Error('Handler error')
-          }
-          return 100
-        },
-        batchSize: 2,
-        startTimestamp,
-        endTimestampExclusive,
       }),
     ).rejects.toThrow('Handler error')
   })


### PR DESCRIPTION
I originally wanted to pass the handler in to the calculateKpiBatch function to facilitate testing, but when actually running the script in CI where we parallelise the campaigns, the logs got very confusing to read. So this PR adds the protocol to the printed logs.

Related to ENG-392