### PR TITLE
chore(refactor): refactor filter logic for multiple params

### DIFF
--- a/scripts/fetchReferrals.ts
+++ b/scripts/fetchReferrals.ts
@@ -69,7 +69,7 @@ export async function fetchReferrals(
     endTimestampExclusive,
   )
   const uniqueEvents = removeDuplicates(referralEvents)
-  const builderAllowList = args.builderAllowList
+  const allowlist = args.builderAllowList
     ? (parse(readFileSync(args.builderAllowList, 'utf-8').toString(), {
         skip_empty_lines: true,
         columns: true,
@@ -79,7 +79,7 @@ export async function fetchReferrals(
     : undefined
 
   const filteredEvents = await args.protocolFilter(uniqueEvents, {
-    allowlist: builderAllowList,
+    allowlist,
   })
   const outputEvents = filteredEvents.map((event) => ({
     referrerId: event.referrerId,

--- a/scripts/fetchReferrals.ts
+++ b/scripts/fetchReferrals.ts
@@ -69,7 +69,7 @@ export async function fetchReferrals(
     endTimestampExclusive,
   )
   const uniqueEvents = removeDuplicates(referralEvents)
-  const allowlist = args.builderAllowList
+  const allowList = args.builderAllowList
     ? (parse(readFileSync(args.builderAllowList, 'utf-8').toString(), {
         skip_empty_lines: true,
         columns: true,
@@ -79,7 +79,7 @@ export async function fetchReferrals(
     : undefined
 
   const filteredEvents = await args.protocolFilter(uniqueEvents, {
-    allowlist,
+    allowList,
   })
   const outputEvents = filteredEvents.map((event) => ({
     referrerId: event.referrerId,

--- a/scripts/fetchReferrals.ts
+++ b/scripts/fetchReferrals.ts
@@ -70,16 +70,17 @@ async function main() {
   )
   const uniqueEvents = removeDuplicates(referralEvents)
   const builderAllowList = args.builderAllowList
-    ? parse(readFileSync(args.builderAllowList, 'utf-8').toString(), {
+    ? (parse(readFileSync(args.builderAllowList, 'utf-8').toString(), {
         skip_empty_lines: true,
         columns: true,
-      }).map(({ referrerId }: { referrerId: Address }) => referrerId)
+      }).map(
+        ({ referrerId }: { referrerId: Address }) => referrerId,
+      ) as Address[])
     : undefined
 
-  const filteredEvents = await args.protocolFilter(
-    uniqueEvents,
-    builderAllowList,
-  )
+  const filteredEvents = await args.protocolFilter(uniqueEvents, {
+    allowlist: builderAllowList,
+  })
   const outputEvents = filteredEvents.map((event) => ({
     referrerId: event.referrerId,
     userAddress: event.userAddress,

--- a/scripts/protocolFilters/aave.ts
+++ b/scripts/protocolFilters/aave.ts
@@ -1,6 +1,6 @@
-import { ReferralEvent } from '../types'
+import { MatcherFn } from '../types'
 
 // TODO: Implement Aave filter
-export async function filter(event: ReferralEvent): Promise<boolean> {
+export const filter: MatcherFn = async (event) => {
   return !!event
 }

--- a/scripts/protocolFilters/aerodrome.ts
+++ b/scripts/protocolFilters/aerodrome.ts
@@ -2,10 +2,10 @@ import {
   AERODROME_NETWORK_ID,
   AERODROME_UNIVERSAL_ROUTER_ADDRESS,
 } from '../calculateKpi/protocols/aerodrome/constants'
-import { ReferralEvent } from '../types'
+import { MatcherFn } from '../types'
 import { filterDrome } from '../utils/filterDrome'
 
-export async function filter(event: ReferralEvent): Promise<boolean> {
+export const filter: MatcherFn = async (event) => {
   return filterDrome({
     event,
     routerAddress: AERODROME_UNIVERSAL_ROUTER_ADDRESS,

--- a/scripts/protocolFilters/arbitrum.ts
+++ b/scripts/protocolFilters/arbitrum.ts
@@ -1,5 +1,5 @@
-import { ReferralEvent } from '../types'
+import { MatcherFn } from '../types'
 
-export async function filter(event: ReferralEvent): Promise<boolean> {
+export const filter: MatcherFn = async (event) => {
   return !!event
 }

--- a/scripts/protocolFilters/beefy.ts
+++ b/scripts/protocolFilters/beefy.ts
@@ -1,9 +1,9 @@
-import { ReferralEvent } from '../types'
+import { MatcherFn } from '../types'
 import { fetchWithBackoff } from '../utils/fetchWithBackoff'
 
 // The user has to have made at least one transaction on Beefy Finance
 // and all transactions have to be after the referral timestamp
-export async function filter(event: ReferralEvent): Promise<boolean> {
+export const filter: MatcherFn = async (event) => {
   const transactions = await fetchInvestorTimeline(event.userAddress)
   return (
     transactions.every(

--- a/scripts/protocolFilters/celo-pg.ts
+++ b/scripts/protocolFilters/celo-pg.ts
@@ -1,5 +1,5 @@
-import { ReferralEvent } from '../types'
+import { MatcherFn } from '../types'
 
-export async function filter(event: ReferralEvent): Promise<boolean> {
+export const filter: MatcherFn = async (event) => {
   return !!event
 }

--- a/scripts/protocolFilters/celoTransactions.test.ts
+++ b/scripts/protocolFilters/celoTransactions.test.ts
@@ -15,15 +15,15 @@ describe('filter', () => {
     expect(result).toBe(true)
   })
 
-  it('returns true if referrerId is in builderAllowList', async () => {
-    const builderAllowList: Address[] = ['0x456', '0x789']
-    const result = await filter(event, builderAllowList)
+  it('returns true if referrerId is in allowlist', async () => {
+    const allowlist: Address[] = ['0x456', '0x789']
+    const result = await filter(event, { allowlist })
     expect(result).toBe(true)
   })
 
-  it('returns false if referrerId is not in builderAllowList', async () => {
-    const builderAllowList: Address[] = ['0x789', '0xabc']
-    const result = await filter(event, builderAllowList)
+  it('returns false if referrerId is not in allowlist', async () => {
+    const allowlist: Address[] = ['0x789', '0xabc']
+    const result = await filter(event, { allowlist })
     expect(result).toBe(false)
   })
 })

--- a/scripts/protocolFilters/celoTransactions.test.ts
+++ b/scripts/protocolFilters/celoTransactions.test.ts
@@ -10,20 +10,20 @@ describe('filter', () => {
     protocol: 'celo-transactions',
   } as ReferralEvent
 
-  it('returns true if no allowlist is passed in', async () => {
+  it('returns true if no allowList is passed in', async () => {
     const result = await filter(event)
     expect(result).toBe(true)
   })
 
-  it('returns true if referrerId is in allowlist', async () => {
-    const allowlist: Address[] = ['0x456', '0x789']
-    const result = await filter(event, { allowlist })
+  it('returns true if referrerId is in allowList', async () => {
+    const allowList: Address[] = ['0x456', '0x789']
+    const result = await filter(event, { allowList })
     expect(result).toBe(true)
   })
 
-  it('returns false if referrerId is not in allowlist', async () => {
-    const allowlist: Address[] = ['0x789', '0xabc']
-    const result = await filter(event, { allowlist })
+  it('returns false if referrerId is not in allowList', async () => {
+    const allowList: Address[] = ['0x789', '0xabc']
+    const result = await filter(event, { allowList })
     expect(result).toBe(false)
   })
 })

--- a/scripts/protocolFilters/celoTransactions.ts
+++ b/scripts/protocolFilters/celoTransactions.ts
@@ -3,12 +3,12 @@ import { MatcherFn } from '../types'
 
 const KNOWN_BUILDERS: Address[] = ['0x22886C71a4C1Fa2824BD86210ead1C310B3d7cf5']
 
-export const filter: MatcherFn = async (event, { allowlist } = {}) => {
+export const filter: MatcherFn = async (event, { allowList } = {}) => {
   // If no allow list is provided, default to accept all referrals
-  if (!allowlist) {
+  if (!allowList) {
     return true
   }
-  return KNOWN_BUILDERS.concat(allowlist).some(
+  return KNOWN_BUILDERS.concat(allowList).some(
     (address) => address.toLowerCase() === event.referrerId.toLowerCase(),
   )
 }

--- a/scripts/protocolFilters/celoTransactions.ts
+++ b/scripts/protocolFilters/celoTransactions.ts
@@ -1,17 +1,14 @@
 import { Address } from 'viem'
-import { ReferralEvent } from '../types'
+import { MatcherFn } from '../types'
 
 const KNOWN_BUILDERS: Address[] = ['0x22886C71a4C1Fa2824BD86210ead1C310B3d7cf5']
 
-export async function filter(
-  event: ReferralEvent,
-  builderAllowList?: Address[],
-): Promise<boolean> {
+export const filter: MatcherFn = async (event, { allowlist } = {}) => {
   // If no allow list is provided, default to accept all referrals
-  if (!builderAllowList) {
+  if (!allowlist) {
     return true
   }
-  return KNOWN_BUILDERS.concat(builderAllowList).some(
+  return KNOWN_BUILDERS.concat(allowlist).some(
     (address) => address.toLowerCase() === event.referrerId.toLowerCase(),
   )
 }

--- a/scripts/protocolFilters/fonbnk.ts
+++ b/scripts/protocolFilters/fonbnk.ts
@@ -9,11 +9,11 @@ import {
   getPayoutWallets,
 } from '../calculateKpi/protocols/fonbnk/helpers'
 import { SUPPORTED_FONBNK_NETWORKS } from '../calculateKpi/protocols/fonbnk/types'
-import { ReferralEvent } from '../types'
+import { MatcherFn } from '../types'
 import { getBlock, getHyperSyncClient } from '../utils'
 import { paginateQuery } from '../utils/hypersyncPagination'
 
-export async function filter(event: ReferralEvent): Promise<boolean> {
+export const filter: MatcherFn = async (event) => {
   if (!isAddress(event.userAddress)) {
     throw new Error(`Invalid user address: ${event.userAddress}`)
   }

--- a/scripts/protocolFilters/index.ts
+++ b/scripts/protocolFilters/index.ts
@@ -2,7 +2,7 @@ import {
   FilterFn,
   Protocol,
   MatcherFn,
-  ProtocolFilterParams,
+  FilterParams,
   ReferralEvent,
 } from '../types'
 import { filter as filterBeefy } from './beefy'
@@ -34,7 +34,7 @@ export const protocolFilters: Record<Protocol, FilterFn> = {
 function _createFilter(matcher: MatcherFn) {
   return async function (
     events: ReferralEvent[],
-    filterParams: ProtocolFilterParams,
+    filterParams: FilterParams,
   ): Promise<ReferralEvent[]> {
     return events.filter((event) => matcher(event, filterParams))
   }

--- a/scripts/protocolFilters/index.ts
+++ b/scripts/protocolFilters/index.ts
@@ -1,4 +1,10 @@
-import { FilterFunction, Protocol, ReferralEvent } from '../types'
+import {
+  FilterFn,
+  Protocol,
+  MatcherFn,
+  ProtocolFilterParams,
+  ReferralEvent,
+} from '../types'
 import { filter as filterBeefy } from './beefy'
 import { filter as filterAerodrome } from './aerodrome'
 import { filter as filterSomm } from './somm'
@@ -11,7 +17,7 @@ import { filter as filterCeloTransactions } from './celoTransactions'
 import { filter as filterRhino } from './rhino'
 import { filter as filterScoutGameV0 } from './scoutGameV0'
 
-export const protocolFilters: Record<Protocol, FilterFunction> = {
+export const protocolFilters: Record<Protocol, FilterFn> = {
   beefy: _createFilter(filterBeefy),
   somm: _createFilter(filterSomm),
   aerodrome: _createFilter(filterAerodrome),
@@ -25,21 +31,11 @@ export const protocolFilters: Record<Protocol, FilterFunction> = {
   'scout-game-v0': _createFilter(filterScoutGameV0),
 }
 
-function _createFilter(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  filter: (event: ReferralEvent, ...args: any[]) => Promise<boolean>,
-) {
+function _createFilter(matcher: MatcherFn) {
   return async function (
     events: ReferralEvent[],
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ...args: any[]
+    filterParams: ProtocolFilterParams,
   ): Promise<ReferralEvent[]> {
-    const filteredEvents = []
-    for (const event of events) {
-      if (await filter(event, ...args)) {
-        filteredEvents.push(event)
-      }
-    }
-    return filteredEvents
+    return events.filter((event) => matcher(event, filterParams))
   }
 }

--- a/scripts/protocolFilters/index.ts
+++ b/scripts/protocolFilters/index.ts
@@ -34,7 +34,7 @@ export const protocolFilters: Record<Protocol, FilterFn> = {
 function _createFilter(matcher: MatcherFn) {
   return async function (
     events: ReferralEvent[],
-    filterParams: FilterParams,
+    filterParams?: FilterParams,
   ): Promise<ReferralEvent[]> {
     return events.filter((event) => matcher(event, filterParams))
   }

--- a/scripts/protocolFilters/index.ts
+++ b/scripts/protocolFilters/index.ts
@@ -36,6 +36,12 @@ function _createFilter(matcher: MatcherFn) {
     events: ReferralEvent[],
     filterParams?: FilterParams,
   ): Promise<ReferralEvent[]> {
-    return events.filter((event) => matcher(event, filterParams))
+    const filteredEvents = []
+    for (const event of events) {
+      if (await matcher(event, filterParams)) {
+        filteredEvents.push(event)
+      }
+    }
+    return filteredEvents
   }
 }

--- a/scripts/protocolFilters/rhino.ts
+++ b/scripts/protocolFilters/rhino.ts
@@ -1,5 +1,5 @@
-import { ReferralEvent } from '../types'
+import { MatcherFn } from '../types'
 
-export async function filter(event: ReferralEvent): Promise<boolean> {
+export const filter: MatcherFn = async (event) => {
   return !!event
 }

--- a/scripts/protocolFilters/scoutGameV0.ts
+++ b/scripts/protocolFilters/scoutGameV0.ts
@@ -1,5 +1,5 @@
-import { ReferralEvent } from '../types'
+import { MatcherFn } from '../types'
 
-export async function filter(event: ReferralEvent): Promise<boolean> {
+export const filter: MatcherFn = async (event) => {
   return !!event
 }

--- a/scripts/protocolFilters/somm.ts
+++ b/scripts/protocolFilters/somm.ts
@@ -1,12 +1,12 @@
 import { erc20Abi, formatUnits, getContract, isAddress } from 'viem'
 import { getEvents } from '../calculateKpi/protocols/somm/getEvents'
 import { getVaults } from '../calculateKpi/protocols/somm/getVaults'
-import { ReferralEvent } from '../types'
 import { getViemPublicClient } from '../utils'
+import { MatcherFn } from '../types'
 
 // The user has to have done at least one TVL event on Somm
 // and their TVL at the time of the referral must be 0
-export async function filter(event: ReferralEvent): Promise<boolean> {
+export const filter: MatcherFn = async (event) => {
   let numTvlEvents = 0
 
   const vaultsInfo = await getVaults()

--- a/scripts/protocolFilters/velodrome.ts
+++ b/scripts/protocolFilters/velodrome.ts
@@ -2,10 +2,10 @@ import {
   VELODROME_NETWORK_ID,
   VELODROME_UNIVERSAL_ROUTER_ADDRESS,
 } from '../calculateKpi/protocols/velodrome/constants'
-import { ReferralEvent } from '../types'
+import { MatcherFn } from '../types'
 import { filterDrome } from '../utils/filterDrome'
 
-export async function filter(event: ReferralEvent): Promise<boolean> {
+export const filter: MatcherFn = async (event) => {
   return filterDrome({
     event,
     routerAddress: VELODROME_UNIVERSAL_ROUTER_ADDRESS,

--- a/scripts/types.ts
+++ b/scripts/types.ts
@@ -17,7 +17,7 @@ export type Protocol = (typeof protocols)[number]
 
 export type FilterFn = (
   events: ReferralEvent[],
-  filterParams: FilterParams,
+  filterParams?: FilterParams,
 ) => Promise<ReferralEvent[]>
 
 export type MatcherFn = (

--- a/scripts/types.ts
+++ b/scripts/types.ts
@@ -17,12 +17,12 @@ export type Protocol = (typeof protocols)[number]
 
 export type FilterFn = (
   events: ReferralEvent[],
-  filterParams: ProtocolFilterParams,
+  filterParams: FilterParams,
 ) => Promise<ReferralEvent[]>
 
 export type MatcherFn = (
   event: ReferralEvent,
-  filterParams?: ProtocolFilterParams,
+  filterParams?: FilterParams,
 ) => Promise<boolean>
 
 export enum NetworkId {
@@ -58,6 +58,6 @@ export interface ReferralEvent {
   protocol: Protocol
 }
 
-export interface ProtocolFilterParams {
+export interface FilterParams {
   allowlist?: Address[]
 }

--- a/scripts/types.ts
+++ b/scripts/types.ts
@@ -60,5 +60,4 @@ export interface ReferralEvent {
 
 export interface ProtocolFilterParams {
   allowlist?: Address[]
-  blacklist?: Address[]
 }

--- a/scripts/types.ts
+++ b/scripts/types.ts
@@ -14,10 +14,16 @@ export const protocols = [
   'scout-game-v0',
 ] as const
 export type Protocol = (typeof protocols)[number]
-export type FilterFunction = (
+
+export type FilterFn = (
   events: ReferralEvent[],
-  builderAllowList?: Address[],
+  filterParams: ProtocolFilterParams,
 ) => Promise<ReferralEvent[]>
+
+export type MatcherFn = (
+  event: ReferralEvent,
+  filterParams?: ProtocolFilterParams,
+) => Promise<boolean>
 
 export enum NetworkId {
   'celo-mainnet' = 'celo-mainnet',
@@ -50,4 +56,9 @@ export interface ReferralEvent {
   timestamp: number
   referrerId: string
   protocol: Protocol
+}
+
+export interface ProtocolFilterParams {
+  allowlist?: Address[]
+  blacklist?: Address[]
 }

--- a/scripts/types.ts
+++ b/scripts/types.ts
@@ -59,5 +59,5 @@ export interface ReferralEvent {
 }
 
 export interface FilterParams {
-  allowlist?: Address[]
+  allowList?: Address[]
 }


### PR DESCRIPTION
### Description

Refactor filter logic to accept multiple filtering params as a separate object, instead of positional arguments.

Before:
```
filter(event, allowlist, blacklist) // easy to accidentally twist the lists
```

After:
```
filter(event, { allowlist, blacklist }) // explicit and sound
```

No existing behavior is changed.

### Test plan

CI

### Related issues

Related to ENG-388