### PR TITLE
chore: ensure delays to avoid rate limits in calculateKpi

### DIFF
--- a/scripts/calculateKpi.test.ts
+++ b/scripts/calculateKpi.test.ts
@@ -138,7 +138,7 @@ describe('_calculateKpiBatch', () => {
     expect(results).toHaveLength(0)
   })
 
-  it('should handle handler errors gracefully', async () => {
+  it('should fail the whole function if there is an error for any user', async () => {
     mockHandler.mockImplementation(async ({ address }) => {
       if (address === '0x123') {
         throw new Error('Handler error')

--- a/scripts/calculateKpi.test.ts
+++ b/scripts/calculateKpi.test.ts
@@ -1,17 +1,28 @@
 import { _calculateKpiBatch } from './calculateKpi'
 
+const mockHandler = jest.fn()
 jest.mock('./calculateKpi/protocols', () => ({
   __esModule: true,
-  default: {},
+  default: {
+    'celo-transactions': (...args: unknown[]) => mockHandler(...args),
+  },
 }))
 
 describe('_calculateKpiBatch', () => {
-  const mockHandler = jest.fn().mockImplementation(async ({ address }) => {
+  mockHandler.mockImplementation(async ({ address }) => {
     return address === '0x123' ? 100 : 50
   })
 
   const startTimestamp = new Date('2024-01-01T00:00:00Z')
   const endTimestampExclusive = new Date('2024-01-31T23:59:59Z')
+  const defaultArgs = {
+    eligibleUsers: [],
+    handler: mockHandler,
+    batchSize: 2,
+    startTimestamp,
+    endTimestampExclusive,
+    protocol: 'celo-transactions' as const,
+  }
 
   beforeEach(() => {
     jest.clearAllMocks()
@@ -37,11 +48,9 @@ describe('_calculateKpiBatch', () => {
     ]
 
     const results = await _calculateKpiBatch({
+      ...defaultArgs,
       eligibleUsers,
-      handler: mockHandler,
       batchSize: 2, // less than the number of eligible users
-      startTimestamp,
-      endTimestampExclusive,
     })
 
     expect(results).toEqual([
@@ -67,11 +76,8 @@ describe('_calculateKpiBatch', () => {
     ]
 
     const results = await _calculateKpiBatch({
+      ...defaultArgs,
       eligibleUsers,
-      handler: mockHandler,
-      batchSize: 2,
-      startTimestamp,
-      endTimestampExclusive,
     })
 
     expect(results).toEqual([
@@ -92,11 +98,8 @@ describe('_calculateKpiBatch', () => {
     ]
 
     await _calculateKpiBatch({
+      ...defaultArgs,
       eligibleUsers,
-      handler: mockHandler,
-      batchSize: 2,
-      startTimestamp,
-      endTimestampExclusive,
     })
     expect(mockHandler).toHaveBeenCalledWith({
       address: '0x123',
@@ -116,11 +119,8 @@ describe('_calculateKpiBatch', () => {
     ]
 
     await _calculateKpiBatch({
+      ...defaultArgs,
       eligibleUsers,
-      handler: mockHandler,
-      batchSize: 2,
-      startTimestamp,
-      endTimestampExclusive,
     })
     expect(mockHandler).toHaveBeenCalledWith({
       address: '0x123',
@@ -131,17 +131,20 @@ describe('_calculateKpiBatch', () => {
 
   it('should handle empty user list', async () => {
     const results = await _calculateKpiBatch({
+      ...defaultArgs,
       eligibleUsers: [],
-      handler: mockHandler,
-      batchSize: 2,
-      startTimestamp,
-      endTimestampExclusive,
     })
 
     expect(results).toHaveLength(0)
   })
 
   it('should handle handler errors gracefully', async () => {
+    mockHandler.mockImplementation(async ({ address }) => {
+      if (address === '0x123') {
+        throw new Error('Handler error')
+      }
+      return 100
+    })
     const eligibleUsers = [
       {
         referrerId: 'ref1',
@@ -157,16 +160,8 @@ describe('_calculateKpiBatch', () => {
 
     await expect(
       _calculateKpiBatch({
+        ...defaultArgs,
         eligibleUsers,
-        handler: async ({ address }) => {
-          if (address === '0x123') {
-            throw new Error('Handler error')
-          }
-          return 100
-        },
-        batchSize: 2,
-        startTimestamp,
-        endTimestampExclusive,
       }),
     ).rejects.toThrow('Handler error')
   })

--- a/scripts/calculateKpi.ts
+++ b/scripts/calculateKpi.ts
@@ -44,7 +44,7 @@ async function calculateKpiBatch({
   protocol: Protocol
 }): Promise<KpiResult[]> {
   const results: KpiResult[] = []
-  const delayMs = (60_000 * BATCH_SIZE) / MAX_REQUESTS_PER_MINUTE
+  const delayPerBatchInMs = (60_000 * BATCH_SIZE) / MAX_REQUESTS_PER_MINUTE
 
   for (let i = 0; i < eligibleUsers.length; i += batchSize) {
     const batch = eligibleUsers.slice(i, i + batchSize)
@@ -96,7 +96,7 @@ async function calculateKpiBatch({
 
     // Add a 1 minute delay to avoid rate limits from DefiLlama
     if (i > 0) {
-      await new Promise((resolve) => setTimeout(resolve, delayMs))
+      await new Promise((resolve) => setTimeout(resolve, delayPerBatchInMs))
     }
   }
 

--- a/scripts/calculateKpi.ts
+++ b/scripts/calculateKpi.ts
@@ -94,10 +94,8 @@ async function calculateKpiBatch({
       ),
     )
 
-    // Add a 1 minute delay to avoid rate limits from DefiLlama
-    if (i > 0) {
-      await new Promise((resolve) => setTimeout(resolve, delayPerBatchInMs))
-    }
+    // Delay to avoid rate limits from DefiLlama
+    await new Promise((resolve) => setTimeout(resolve, delayPerBatchInMs))
   }
 
   return results

--- a/scripts/calculateKpi.ts
+++ b/scripts/calculateKpi.ts
@@ -10,7 +10,10 @@ import { dirname, join } from 'path'
 // Buffer to account for time it takes for a referral to be registered, since the referral transaction is made first and the referral registration happens on a schedule
 const REFERRAL_TIME_BUFFER_IN_MS = 30 * 60 * 1000 // 30 minutes
 // Calculate KPIs for end users in batches to speed things up
-const BATCH_SIZE = 10
+const BATCH_SIZE = 20
+
+// DefiLlama API limit, at worst we need to fetch the referral block timestamp for every user
+const MAX_REQUESTS_PER_MINUTE = 500
 
 interface KpiResult {
   referrerId: string
@@ -41,6 +44,7 @@ async function calculateKpiBatch({
   protocol: Protocol
 }): Promise<KpiResult[]> {
   const results: KpiResult[] = []
+  const delayMs = (60_000 * BATCH_SIZE) / MAX_REQUESTS_PER_MINUTE
 
   for (let i = 0; i < eligibleUsers.length; i += batchSize) {
     const batch = eligibleUsers.slice(i, i + batchSize)
@@ -89,6 +93,11 @@ async function calculateKpiBatch({
         (result): result is NonNullable<typeof result> => result !== null,
       ),
     )
+
+    // Add a 1 minute delay to avoid rate limits from DefiLlama
+    if (i > 0) {
+      await new Promise((resolve) => setTimeout(resolve, delayMs))
+    }
   }
 
   return results

--- a/scripts/calculateKpi/protocols/utils/events.ts
+++ b/scripts/calculateKpi/protocols/utils/events.ts
@@ -37,8 +37,11 @@ async function _getNearestBlock(
     `${DEFI_LLAMA_API_URL}/block/${defiLlamaChain}/${unixTimestamp}`,
   )
   if (!response.ok) {
+    const errorBody = await response.text()
     throw new Error(
-      `Error while fetching block timestamp from DefiLlama: ${response}`,
+      `Error while fetching block timestamp from DefiLlama:\n` +
+        `Status: ${response.status} ${response.statusText}\n` +
+        `Body: ${errorBody}`,
     )
   }
   const blockTimestampData = (await response.json()) as BlockTimestampData


### PR DESCRIPTION
When running the calculateKpi scripts on CI, it was the _getNearestBlock function that started failing. On closer inspection, it seems envio has no rate limits but DefiLlama has a rate limit of 500 requests/min. In the worst case, we call _getNearestBlock for every user in the reward period if they were referred within the period (i.e. we need to get the block corresponding to their referral)

This PR adds:
- better error messaging on _getNearestBlock (the error response was previously logged as `[object Object]`
- delay after every kpi batch transaction to keep requests under the rate limit 

Related to ENG-392