### PR TITLE
refactor: return outputFile from getArgs

### DIFF
--- a/scripts/calculateKpi.ts
+++ b/scripts/calculateKpi.ts
@@ -99,17 +99,8 @@ export async function calculateKpi(args: Awaited<ReturnType<typeof getArgs>>) {
   const endTimestampExclusive = new Date(args.endTimestampExclusive)
   const protocol = args.protocol
 
-  const folderPath = join(
-    args.datadir,
-    protocol,
-    toPeriodFolderName({
-      startTimestamp,
-      endTimestampExclusive,
-    }),
-  )
-
-  const inputFile = join(folderPath, 'referrals.csv')
-  const outputFile = join(folderPath, 'kpi.csv')
+  const inputFile = join(args.outputDir, 'referrals.csv')
+  const outputFile = join(args.outputDir, 'kpi.csv')
 
   const eligibleUsers: ReferralData[] = parse(
     readFileSync(inputFile, 'utf-8').toString(),
@@ -164,8 +155,17 @@ async function getArgs() {
       default: 'rewards',
     }).argv
 
+  const outputDir = join(
+    argv['datadir'],
+    argv['protocol'],
+    toPeriodFolderName({
+      startTimestamp: new Date(argv['start-timestamp']),
+      endTimestampExclusive: new Date(argv['end-timestamp']),
+    }),
+  )
+
   return {
-    datadir: argv['datadir'],
+    outputDir,
     protocol: argv['protocol'],
     startTimestamp: argv['start-timestamp'],
     endTimestampExclusive: argv['end-timestamp'],

--- a/scripts/fetchReferrals.ts
+++ b/scripts/fetchReferrals.ts
@@ -46,11 +46,19 @@ async function getArgs() {
       type: 'string',
     }).argv
 
+  const outputDir = join(
+    argv['datadir'],
+    argv['protocol'],
+    toPeriodFolderName({
+      startTimestamp: new Date(argv['start-timestamp']),
+      endTimestampExclusive: new Date(argv['end-timestamp']),
+    }),
+  )
+
   return {
-    datadir: argv['datadir'],
     protocol: argv['protocol'] as Protocol,
     protocolFilter: protocolFilters[argv['protocol'] as Protocol],
-    output: `${argv['protocol']}-referrals.csv`,
+    outputDir,
     useStaging: argv['use-staging'],
     builderAllowList: argv['builder-allowlist-file'],
     startTimestamp: argv['start-timestamp'],
@@ -86,15 +94,7 @@ export async function fetchReferrals(
     timestamp: new Date(event.timestamp * 1000).toISOString(),
   }))
 
-  const outputDir = join(
-    args.datadir,
-    args.protocol,
-    toPeriodFolderName({
-      startTimestamp: new Date(args.startTimestamp),
-      endTimestampExclusive: new Date(args.endTimestampExclusive),
-    }),
-  )
-  const outputFile = `${outputDir}/referrals.csv`
+  const outputFile = `${args.outputDir}/referrals.csv`
 
   // Create directory if it doesn't exist
   mkdirSync(dirname(outputFile), { recursive: true })
@@ -104,7 +104,7 @@ export async function fetchReferrals(
   console.log(`Wrote results to ${outputFile}`)
 
   if (args.builderAllowList) {
-    const allowListOutputFile = `${outputDir}/builder-allowlist.csv`
+    const allowListOutputFile = `${args.outputDir}/builder-allowlist.csv`
     copyFileSync(args.builderAllowList, allowListOutputFile)
     console.log(`Copied builder allowlist to ${allowListOutputFile}`)
   }


### PR DESCRIPTION
This change does not affect how we are calling the scripts from the CLI but enables us to specify the full output path when calling the function from another script (I want to be able to pass a custom filepath here when running the calculations from CI)

Related to ENG-392