### PR TITLE
chore: run the KPI workload every 2 hours

### DIFF
--- a/.github/workflows/calculate-and-upload-KPIs.yaml
+++ b/.github/workflows/calculate-and-upload-KPIs.yaml
@@ -2,7 +2,7 @@ name: Calculate and Upload KPIs
 
 on:
   schedule:
-    - cron: '0 * * * *' # Runs at minute 0 of every hour
+    - cron: '0 */2 * * *' # Runs at minute 0 of every 2nd hour
   workflow_dispatch:
     inputs:
       timestamp:


### PR DESCRIPTION
it takes over 1 hr to run now, so every hour is too frequent