### PR TITLE
feat: improve DefiLlama rate limit handling

### DIFF
--- a/.github/workflows/calculate-and-upload-KPIs.yaml
+++ b/.github/workflows/calculate-and-upload-KPIs.yaml
@@ -28,7 +28,8 @@ jobs:
       - name: Calculate and upload KPIs for the current reward period
         run: |
           yarn ts-node scripts/uploadCurrentPeriodKpis.ts \
-            --calculation-timestamp ${{ github.event.inputs.timestamp }}
+            --calculation-timestamp ${{ github.event.inputs.timestamp }} \
+            --dry-run
 
       # TODO(kathy)
       # - name: Notify Slack on Failure

--- a/.github/workflows/calculate-and-upload-KPIs.yaml
+++ b/.github/workflows/calculate-and-upload-KPIs.yaml
@@ -8,7 +8,7 @@ on:
       timestamp:
         description: 'KPIs are calculated for the reward period that includes this timestamp, from the start of the period up to this timestamp. (new Date() compatible epoch milliseconds or string)'
         required: true
-  # pull_request:
+  pull_request:
 
 jobs:
   calculate-and-upload-KPIs:

--- a/.github/workflows/calculate-and-upload-KPIs.yaml
+++ b/.github/workflows/calculate-and-upload-KPIs.yaml
@@ -8,7 +8,7 @@ on:
       timestamp:
         description: 'KPIs are calculated for the reward period that includes this timestamp, from the start of the period up to this timestamp. (new Date() compatible epoch milliseconds or string)'
         required: true
-  pull_request:
+  # pull_request:
 
 jobs:
   calculate-and-upload-KPIs:

--- a/.github/workflows/calculate-and-upload-KPIs.yaml
+++ b/.github/workflows/calculate-and-upload-KPIs.yaml
@@ -8,6 +8,7 @@ on:
       timestamp:
         description: 'KPIs are calculated for the reward period that includes this timestamp, from the start of the period up to this timestamp. (new Date() compatible epoch milliseconds or string)'
         required: true
+  pull_request:
 
 jobs:
   calculate-and-upload-KPIs:

--- a/.github/workflows/calculate-and-upload-KPIs.yaml
+++ b/.github/workflows/calculate-and-upload-KPIs.yaml
@@ -2,13 +2,12 @@ name: Calculate and Upload KPIs
 
 on:
   schedule:
-    - cron: '0 */2 * * *' # Runs at minute 0 of every 2nd hour
+    - cron: '0 * * * *' # Runs at minute 0 of every hour
   workflow_dispatch:
     inputs:
       timestamp:
         description: 'KPIs are calculated for the reward period that includes this timestamp, from the start of the period up to this timestamp. (new Date() compatible epoch milliseconds or string)'
         required: true
-  pull_request:
 
 jobs:
   calculate-and-upload-KPIs:
@@ -29,7 +28,6 @@ jobs:
         run: |
           yarn ts-node scripts/uploadCurrentPeriodKpis.ts \
             --calculation-timestamp ${{ github.event.inputs.timestamp }} \
-            --dry-run
 
       # TODO(kathy)
       # - name: Notify Slack on Failure

--- a/.github/workflows/calculate-and-upload-KPIs.yaml
+++ b/.github/workflows/calculate-and-upload-KPIs.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Calculate and upload KPIs for the current reward period
         run: |
           yarn ts-node scripts/uploadCurrentPeriodKpis.ts \
-            --calculation-timestamp ${{ github.event.inputs.timestamp }} \
+            --calculation-timestamp ${{ github.event.inputs.timestamp }}
 
       # TODO(kathy)
       # - name: Notify Slack on Failure

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@typescript-eslint/parser": "^8.33.0",
     "@valora/prettier-config": "^0.0.1",
     "bignumber.js": "^9.2.1",
+    "bottleneck": "^2.19.5",
     "chai": "^4.5.0",
     "csv-parse": "^5.6.0",
     "csv-stringify": "^6.5.2",

--- a/scripts/calculateKpi.ts
+++ b/scripts/calculateKpi.ts
@@ -85,6 +85,10 @@ async function calculateKpiBatch({
         (result): result is NonNullable<typeof result> => result !== null,
       ),
     )
+
+    console.log(
+      `Finished processing batch ${Math.floor(i / batchSize) + 1}/${Math.ceil(eligibleUsers.length / batchSize)} for campaign ${protocol}`,
+    )
   }
 
   return results

--- a/scripts/calculateKpi.ts
+++ b/scripts/calculateKpi.ts
@@ -8,9 +8,6 @@ const REFERRAL_TIME_BUFFER_IN_MS = 30 * 60 * 1000 // 30 minutes
 // Calculate KPIs for end users in batches to speed things up
 const BATCH_SIZE = 20
 
-// DefiLlama API limit, at worst we need to fetch the referral block timestamp for every user
-const MAX_REQUESTS_PER_MINUTE = 500
-
 interface KpiResult {
   referrerId: string
   userAddress: string
@@ -40,7 +37,6 @@ async function calculateKpiBatch({
   protocol: Protocol
 }): Promise<KpiResult[]> {
   const results: KpiResult[] = []
-  const delayPerBatchInMs = (60_000 * BATCH_SIZE) / MAX_REQUESTS_PER_MINUTE
 
   for (let i = 0; i < eligibleUsers.length; i += batchSize) {
     const batch = eligibleUsers.slice(i, i + batchSize)
@@ -89,9 +85,6 @@ async function calculateKpiBatch({
         (result): result is NonNullable<typeof result> => result !== null,
       ),
     )
-
-    // Delay to avoid rate limits from DefiLlama
-    await new Promise((resolve) => setTimeout(resolve, delayPerBatchInMs))
   }
 
   return results

--- a/scripts/calculateKpi.ts
+++ b/scripts/calculateKpi.ts
@@ -85,10 +85,6 @@ async function calculateKpiBatch({
         (result): result is NonNullable<typeof result> => result !== null,
       ),
     )
-
-    console.log(
-      `Finished processing batch ${Math.floor(i / batchSize) + 1}/${Math.ceil(eligibleUsers.length / batchSize)} for campaign ${protocol}`,
-    )
   }
 
   return results

--- a/scripts/calculateKpi/protocols/utils/events.ts
+++ b/scripts/calculateKpi/protocols/utils/events.ts
@@ -35,6 +35,8 @@ async function _getNearestBlock(
   const unixTimestamp = Math.floor(timestamp.getTime() / 1000)
   const defiLlamaChain = NETWORK_ID_TO_DEFI_LLAMA_CHAIN[networkId]
 
+  console.log('======fetching block timestamp======')
+
   const response = await fetchWithTimeout(
     `${DEFI_LLAMA_API_URL}/block/${defiLlamaChain}/${unixTimestamp}`,
   )

--- a/scripts/calculateKpi/protocols/utils/events.ts
+++ b/scripts/calculateKpi/protocols/utils/events.ts
@@ -52,8 +52,8 @@ async function _getNearestBlock(
 
 // Set up a Bottleneck instance to keep requests to DefiLlama under the allowed rate limit (500 requests per minute).
 const limiter = new Bottleneck({
-  reservoir: 500, // initial number of available requests
-  reservoirRefreshAmount: 500, // how many tokens to add on refresh
+  reservoir: 450, // initial number of available requests
+  reservoirRefreshAmount: 450, // how many tokens to add on refresh
   reservoirRefreshInterval: 60 * 1000, // refresh every 60 seconds
   minTime: 0, // no minimum time between requests
 })

--- a/scripts/calculateKpi/protocols/utils/events.ts
+++ b/scripts/calculateKpi/protocols/utils/events.ts
@@ -35,8 +35,6 @@ async function _getNearestBlock(
   const unixTimestamp = Math.floor(timestamp.getTime() / 1000)
   const defiLlamaChain = NETWORK_ID_TO_DEFI_LLAMA_CHAIN[networkId]
 
-  console.log('======fetching block timestamp======')
-
   const response = await fetchWithTimeout(
     `${DEFI_LLAMA_API_URL}/block/${defiLlamaChain}/${unixTimestamp}`,
   )

--- a/scripts/fetchReferrals.ts
+++ b/scripts/fetchReferrals.ts
@@ -87,11 +87,13 @@ export async function fetchReferrals(
     : undefined
 
   const filteredEvents = await args.protocolFilter(uniqueEvents, { allowList })
-  const outputEvents = filteredEvents.map((event) => ({
-    referrerId: event.referrerId,
-    userAddress: event.userAddress,
-    timestamp: new Date(event.timestamp * 1000).toISOString(),
-  }))
+  const outputEvents = filteredEvents
+    .map((event) => ({
+      referrerId: event.referrerId,
+      userAddress: event.userAddress,
+      timestamp: new Date(event.timestamp * 1000).toISOString(),
+    }))
+    .slice(33800)
 
   const outputFile = join(args.outputDir, 'referrals.csv')
 

--- a/scripts/fetchReferrals.ts
+++ b/scripts/fetchReferrals.ts
@@ -87,13 +87,11 @@ export async function fetchReferrals(
     : undefined
 
   const filteredEvents = await args.protocolFilter(uniqueEvents, { allowList })
-  const outputEvents = filteredEvents
-    .map((event) => ({
-      referrerId: event.referrerId,
-      userAddress: event.userAddress,
-      timestamp: new Date(event.timestamp * 1000).toISOString(),
-    }))
-    .reverse()
+  const outputEvents = filteredEvents.map((event) => ({
+    referrerId: event.referrerId,
+    userAddress: event.userAddress,
+    timestamp: new Date(event.timestamp * 1000).toISOString(),
+  }))
 
   const outputFile = join(args.outputDir, 'referrals.csv')
 

--- a/scripts/fetchReferrals.ts
+++ b/scripts/fetchReferrals.ts
@@ -93,7 +93,7 @@ export async function fetchReferrals(
       userAddress: event.userAddress,
       timestamp: new Date(event.timestamp * 1000).toISOString(),
     }))
-    .slice(33800)
+    .reverse()
 
   const outputFile = join(args.outputDir, 'referrals.csv')
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3487,6 +3487,11 @@ bn.js@^5.1.2, bn.js@^5.2.0, bn.js@^5.2.1:
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-5.2.1.tgz#0bc527a6a0d18d0aa8d5b0538ce4a77dccfa7b70"
   integrity sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==
 
+bottleneck@^2.19.5:
+  version "2.19.5"
+  resolved "https://registry.yarnpkg.com/bottleneck/-/bottleneck-2.19.5.tgz#5df0b90f59fd47656ebe63c78a98419205cadd91"
+  integrity sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==
+
 bowser@^2.11.0:
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/bowser/-/bowser-2.11.0.tgz#5ca3c35757a7aa5771500c70a73a9f91ef420a8f"
@@ -8091,16 +8096,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -8157,14 +8153,7 @@ string_decoder@^1.1.1, string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -8877,16 +8866,7 @@ workerpool@^6.5.1:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.5.1.tgz#060f73b39d0caf97c6db64da004cd01b4c099544"
   integrity sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
This PR adds the `bottleneck` npm package to manage the DefiLlama rate limit at the api request level. This is much more efficient than managing at the kpi calc level, since some calculations don't require a request to DefiLlama.

Example of a [job](https://github.com/divvi-xyz/divvi-protocol-v0/actions/runs/15451499250/job/43494472674?pr=220) running with this change, which took ~15 minutes. It ran the same logic as the other jobs in the CI which take ~90 minutes.

With this change, I could also change the frequency of the scheduled calc and upload job back to 1 hour.

Related to ENG-414