### PR TITLE
fix: missing Lisk campaign provider id

### DIFF
--- a/scripts/utils/referrals.ts
+++ b/scripts/utils/referrals.ts
@@ -18,6 +18,7 @@ const REWARDS_PROVIDERS: Partial<Record<Protocol, Address>> = {
   'celo-transactions': '0x5f0a55FaD9424ac99429f635dfb9bF20c3360Ab8', // celo proof of impact
   'celo-pg': '0x0423189886D7966f0DD7E7d256898DAeEE625dca',
   'scout-game-v0': '0xC95876688026BE9d6fA7a7c33328bD013efFa2Bb',
+  'lisk-v0': '0x7bEb0e14F8D2e6f6678Cc30d867787B384b19e20',
 }
 
 // Remove duplicate events, keeping only the earliest event for each user


### PR DESCRIPTION
Without this change the scripts don't pick up the referrals correctly, oops 🙈

Related to ENG-415