### PR TITLE
fix: upload kpis CI job optional input and logs

### DIFF
--- a/.github/workflows/calculate-and-upload-KPIs.yaml
+++ b/.github/workflows/calculate-and-upload-KPIs.yaml
@@ -10,7 +10,6 @@ on:
         required: true
       protocol:
         description: 'Protocol to calculate KPIs for, e.g. celo-pg, scout-game-v0, lisk-v0'
-        required: true
 
 jobs:
   calculate-and-upload-KPIs:

--- a/scripts/calculateKpi.ts
+++ b/scripts/calculateKpi.ts
@@ -51,10 +51,6 @@ async function calculateKpiBatch({
 
     const batchPromises = batch.map(
       async ({ referrerId, userAddress, timestamp }) => {
-        console.log(
-          `Calculating KPI for ${userAddress} for campaign ${protocol}`,
-        )
-
         const referralTimestamp = new Date(
           Date.parse(timestamp) - REFERRAL_TIME_BUFFER_IN_MS,
         )

--- a/scripts/uploadCurrentPeriodKpis.ts
+++ b/scripts/uploadCurrentPeriodKpis.ts
@@ -271,14 +271,11 @@ async function uploadCurrentPeriodKpis(
   console.log(
     `📣 Calculating KPIs for protocol(s) ${campaignsToCalculate
       .map((campaign) => campaign.protocol)
-      .join(
-        ', ',
-      )}, from ${new Date(startOfCalculationHour).toISOString()} to ${endTimestampExclusive} (exclusive)`,
+      .join(', ')}`,
   )
 
   // Due to the DefiLlama API rate limit, there is no point in parallelising the calculations across campaigns
   for (const campaign of campaignsToCalculate) {
-    console.log(`🧮 Calculating KPIs for campaign ${campaign.protocol}`)
     const campaignStartTimestamp = Date.parse(
       campaign.rewardsPeriods[0].startTimestamp,
     )
@@ -309,6 +306,10 @@ async function uploadCurrentPeriodKpis(
         `No active period found for campaign ${campaign.protocol}`,
       )
     }
+
+    console.log(
+      `🧮 Calculating KPIs for campaign ${campaign.protocol}, from ${currentPeriod.startTimestamp} to ${endTimestampExclusive} (exclusive)`,
+    )
 
     const datadir = 'kpi'
 


### PR DESCRIPTION
This PR has some misc fixes:
- the protocol input in the manual dispatch should be optional (undefined = calculate for all campaigns)
- remove some noisy logs
- fix some incorrect logs