### PR TITLE
chore: add number of referrals to reward.json

### DIFF
--- a/scripts/calculateRewards/celoPG.ts
+++ b/scripts/calculateRewards/celoPG.ts
@@ -58,7 +58,7 @@ export function calculateRewardsCeloPG({
     return {
       referrerId,
       rewardAmount: rewardAmount.toFixed(0, BigNumber.ROUND_DOWN),
-      numReferrals: referrerReferrals[referrerId],
+      referralCount: referrerReferrals[referrerId],
       kpi,
       linearProportion: linearProportion.toFixed(8, BigNumber.ROUND_DOWN),
       powerProportion: powerProportion.toFixed(8, BigNumber.ROUND_DOWN),

--- a/scripts/calculateRewards/celoPG.ts
+++ b/scripts/calculateRewards/celoPG.ts
@@ -6,6 +6,7 @@ import BigNumber from 'bignumber.js'
 import { createAddRewardSafeTransactionJSON } from '../utils/createSafeTransactionsBatch'
 import filterExcludedReferrerIds from '../utils/filterExcludedReferralIds'
 import { ResultDirectory } from '../../src/resultDirectory'
+import { getReferrerMetricsFromKpi } from './getReferrerMetricsFromKpi'
 
 const REWARD_POOL_ADDRESS = '0xc273fB49C5c291F7C697D0FcEf8ce34E985008F3' // on Celo mainnet
 
@@ -25,17 +26,11 @@ export function calculateRewardsCeloPG({
     1 - proportionLinear,
   )
 
-  const referrerKpis = kpiData.reduce(
-    (acc, row) => {
-      if (!(row.referrerId in acc)) {
-        acc[row.referrerId] = BigInt(row.kpi)
-      } else {
-        acc[row.referrerId] += BigInt(row.kpi)
-      }
-      return acc
-    },
-    {} as Record<string, bigint>,
-  )
+  const {
+    referrerReferrals,
+    referrerKpis,
+    totalKpi: totalLinear,
+  } = getReferrerMetricsFromKpi(kpiData)
 
   const referrerPowerKpis = Object.entries(referrerKpis).reduce(
     (acc, [referrerId, kpi]) => {
@@ -45,18 +40,13 @@ export function calculateRewardsCeloPG({
     {} as Record<string, BigNumber>,
   )
 
-  const total = Object.values(referrerKpis).reduce(
-    (sum, value) => sum + value,
-    BigInt(0),
-  )
-
   const totalPower = Object.values(referrerPowerKpis).reduce(
     (sum, value) => sum.plus(value),
     BigNumber(0),
   )
 
   const rewards = Object.entries(referrerKpis).map(([referrerId, kpi]) => {
-    const linearProportion = BigNumber(kpi).div(total)
+    const linearProportion = BigNumber(kpi).div(totalLinear)
     const powerProportion = BigNumber(referrerPowerKpis[referrerId]).div(
       totalPower,
     )
@@ -68,7 +58,7 @@ export function calculateRewardsCeloPG({
     return {
       referrerId,
       rewardAmount: rewardAmount.toFixed(0, BigNumber.ROUND_DOWN),
-
+      numReferrals: referrerReferrals[referrerId],
       kpi,
       linearProportion: linearProportion.toFixed(8, BigNumber.ROUND_DOWN),
       powerProportion: powerProportion.toFixed(8, BigNumber.ROUND_DOWN),

--- a/scripts/calculateRewards/getReferrerMetricsFromKpi.test.ts
+++ b/scripts/calculateRewards/getReferrerMetricsFromKpi.test.ts
@@ -1,0 +1,37 @@
+import { getReferrerMetricsFromKpi } from './getReferrerMetricsFromKpi'
+import { KpiRow } from '../../src/resultDirectory'
+
+describe('getReferrerMetricsFromKpi', () => {
+  it('should handle empty KPI array', () => {
+    const result = getReferrerMetricsFromKpi([])
+    expect(result).toEqual({
+      referrerReferrals: {},
+      referrerKpis: {},
+      totalKpi: BigInt(0),
+    })
+  })
+
+  it('should calculate metrics for multiple referrers', () => {
+    const kpi: KpiRow[] = [
+      { referrerId: 'ref1', userAddress: 'user1', kpi: '100' },
+      { referrerId: 'ref2', userAddress: 'user2', kpi: '200' },
+      { referrerId: 'ref1', userAddress: 'user3', kpi: '300' },
+      { referrerId: 'ref3', userAddress: 'user4', kpi: '400' },
+    ]
+
+    const result = getReferrerMetricsFromKpi(kpi)
+    expect(result).toEqual({
+      referrerReferrals: {
+        ref1: 2,
+        ref2: 1,
+        ref3: 1,
+      },
+      referrerKpis: {
+        ref1: BigInt(400),
+        ref2: BigInt(200),
+        ref3: BigInt(400),
+      },
+      totalKpi: BigInt(1000),
+    })
+  })
+})

--- a/scripts/calculateRewards/getReferrerMetricsFromKpi.ts
+++ b/scripts/calculateRewards/getReferrerMetricsFromKpi.ts
@@ -6,14 +6,11 @@ export function getReferrerMetricsFromKpi(kpi: KpiRow[]) {
   let totalKpi = BigInt(0)
 
   kpi.forEach((row) => {
-    if (!referrerReferrals[row.referrerId]) {
+    if (!(row.referrerId in referrerReferrals)) {
       referrerReferrals[row.referrerId] = 0
-    }
-    referrerReferrals[row.referrerId]++
-
-    if (referrerKpis[row.referrerId] === undefined) {
       referrerKpis[row.referrerId] = BigInt(0)
     }
+    referrerReferrals[row.referrerId]++
     referrerKpis[row.referrerId] += BigInt(row.kpi)
 
     totalKpi += BigInt(row.kpi)

--- a/scripts/calculateRewards/getReferrerMetricsFromKpi.ts
+++ b/scripts/calculateRewards/getReferrerMetricsFromKpi.ts
@@ -1,0 +1,23 @@
+import { KpiRow } from '../../src/resultDirectory'
+
+export function getReferrerMetricsFromKpi(kpi: KpiRow[]) {
+  const referrerReferrals: Record<string, number> = {}
+  const referrerKpis: Record<string, bigint> = {}
+  let totalKpi = BigInt(0)
+
+  kpi.forEach((row) => {
+    if (!referrerReferrals[row.referrerId]) {
+      referrerReferrals[row.referrerId] = 0
+    }
+    referrerReferrals[row.referrerId]++
+
+    if (referrerKpis[row.referrerId] === undefined) {
+      referrerKpis[row.referrerId] = BigInt(0)
+    }
+    referrerKpis[row.referrerId] += BigInt(row.kpi)
+
+    totalKpi += BigInt(row.kpi)
+  })
+
+  return { referrerReferrals, referrerKpis, totalKpi }
+}

--- a/scripts/calculateRewards/liskV0.ts
+++ b/scripts/calculateRewards/liskV0.ts
@@ -6,6 +6,7 @@ import BigNumber from 'bignumber.js'
 import { createAddRewardSafeTransactionJSON } from '../utils/createSafeTransactionsBatch'
 import filterExcludedReferrerIds from '../utils/filterExcludedReferralIds'
 import { ResultDirectory } from '../../src/resultDirectory'
+import { getReferrerMetricsFromKpi } from './getReferrerMetricsFromKpi'
 
 const REWARD_POOL_ADDRESS = '0xBBF7B15C819102B137A96703E63eCF1c3d57CC68'
 const REWARD_AMOUNT_IN_DECIMALS = '15000'
@@ -26,17 +27,11 @@ export function calculateRewardsLiskV0({
     1 - proportionLinear,
   )
 
-  const referrerKpis = kpiData.reduce(
-    (acc, row) => {
-      if (!(row.referrerId in acc)) {
-        acc[row.referrerId] = BigInt(row.kpi)
-      } else {
-        acc[row.referrerId] += BigInt(row.kpi)
-      }
-      return acc
-    },
-    {} as Record<string, bigint>,
-  )
+  const {
+    referrerReferrals,
+    referrerKpis,
+    totalKpi: totalLinear,
+  } = getReferrerMetricsFromKpi(kpiData)
 
   const referrerPowerKpis = Object.entries(referrerKpis).reduce(
     (acc, [referrerId, kpi]) => {
@@ -46,18 +41,13 @@ export function calculateRewardsLiskV0({
     {} as Record<string, BigNumber>,
   )
 
-  const total = Object.values(referrerKpis).reduce(
-    (sum, value) => sum + value,
-    BigInt(0),
-  )
-
   const totalPower = Object.values(referrerPowerKpis).reduce(
     (sum, value) => sum.plus(value),
     BigNumber(0),
   )
 
   const rewards = Object.entries(referrerKpis).map(([referrerId, kpi]) => {
-    const linearProportion = BigNumber(kpi).div(total)
+    const linearProportion = BigNumber(kpi).div(totalLinear)
     const powerProportion = BigNumber(referrerPowerKpis[referrerId]).div(
       totalPower,
     )
@@ -69,7 +59,7 @@ export function calculateRewardsLiskV0({
     return {
       referrerId,
       rewardAmount: rewardAmount.toFixed(0, BigNumber.ROUND_DOWN),
-
+      numReferrals: referrerReferrals[referrerId],
       kpi,
       linearProportion: linearProportion.toFixed(8, BigNumber.ROUND_DOWN),
       powerProportion: powerProportion.toFixed(8, BigNumber.ROUND_DOWN),

--- a/scripts/calculateRewards/liskV0.ts
+++ b/scripts/calculateRewards/liskV0.ts
@@ -59,7 +59,7 @@ export function calculateRewardsLiskV0({
     return {
       referrerId,
       rewardAmount: rewardAmount.toFixed(0, BigNumber.ROUND_DOWN),
-      numReferrals: referrerReferrals[referrerId],
+      referralCount: referrerReferrals[referrerId],
       kpi,
       linearProportion: linearProportion.toFixed(8, BigNumber.ROUND_DOWN),
       powerProportion: powerProportion.toFixed(8, BigNumber.ROUND_DOWN),

--- a/src/proportionalPrizeContest.test.ts
+++ b/src/proportionalPrizeContest.test.ts
@@ -27,13 +27,13 @@ describe('calculateProportionalPrizeContest', () => {
         referrerId: 'ref1',
         rewardAmount: '500',
         kpi: 300n,
-        numReferrals: 2,
+        referralCount: 2,
       },
       {
         referrerId: 'ref2',
         rewardAmount: '500',
         kpi: 300n,
-        numReferrals: 1,
+        referralCount: 1,
       },
     ])
   })
@@ -56,13 +56,13 @@ describe('calculateProportionalPrizeContest', () => {
         referrerId: 'ref1',
         rewardAmount: '0',
         kpi: 0n,
-        numReferrals: 1,
+        referralCount: 1,
       },
       {
         referrerId: 'ref2',
         rewardAmount: '1000', // All rewards go to ref2
         kpi: 100n,
-        numReferrals: 1,
+        referralCount: 1,
       },
     ])
   })
@@ -100,13 +100,13 @@ describe('calculateProportionalPrizeContest', () => {
         referrerId: 'ref1',
         rewardAmount: '0',
         kpi: 0n,
-        numReferrals: 1,
+        referralCount: 1,
       },
       {
         referrerId: 'ref2',
         rewardAmount: '0',
         kpi: 0n,
-        numReferrals: 1,
+        referralCount: 1,
       },
     ])
   })
@@ -131,13 +131,13 @@ describe('calculateSqrtProportionalPrizeContest', () => {
         referrerId: 'ref1',
         rewardAmount: '200',
         kpi: 1n,
-        numReferrals: 1,
+        referralCount: 1,
       },
       {
         referrerId: 'ref2',
         rewardAmount: '800',
         kpi: 16n,
-        numReferrals: 2,
+        referralCount: 2,
       },
     ])
   })

--- a/src/proportionalPrizeContest.test.ts
+++ b/src/proportionalPrizeContest.test.ts
@@ -27,11 +27,13 @@ describe('calculateProportionalPrizeContest', () => {
         referrerId: 'ref1',
         rewardAmount: '500',
         kpi: 300n,
+        numReferrals: 2,
       },
       {
         referrerId: 'ref2',
         rewardAmount: '500',
         kpi: 300n,
+        numReferrals: 1,
       },
     ])
   })
@@ -51,9 +53,16 @@ describe('calculateProportionalPrizeContest', () => {
     // Only ref2 should get rewards since ref1 has zero KPI
     expect(result).to.deep.equal([
       {
+        referrerId: 'ref1',
+        rewardAmount: '0',
+        kpi: 0n,
+        numReferrals: 1,
+      },
+      {
         referrerId: 'ref2',
         rewardAmount: '1000', // All rewards go to ref2
         kpi: 100n,
+        numReferrals: 1,
       },
     ])
   })
@@ -86,7 +95,20 @@ describe('calculateProportionalPrizeContest', () => {
       rewards,
     })
 
-    expect(result).to.deep.equal([])
+    expect(result).to.deep.equal([
+      {
+        referrerId: 'ref1',
+        rewardAmount: '0',
+        kpi: 0n,
+        numReferrals: 1,
+      },
+      {
+        referrerId: 'ref2',
+        rewardAmount: '0',
+        kpi: 0n,
+        numReferrals: 1,
+      },
+    ])
   })
 })
 
@@ -109,11 +131,13 @@ describe('calculateSqrtProportionalPrizeContest', () => {
         referrerId: 'ref1',
         rewardAmount: '200',
         kpi: 1n,
+        numReferrals: 1,
       },
       {
         referrerId: 'ref2',
         rewardAmount: '800',
         kpi: 16n,
+        numReferrals: 2,
       },
     ])
   })

--- a/src/proportionalPrizeContest.ts
+++ b/src/proportionalPrizeContest.ts
@@ -19,13 +19,21 @@ export function calculateProportionalPrizeContest({
 
   const rewardsPerReferrer = Object.entries(referrerKpis).map(
     ([referrerId, kpi]) => {
+      if (totalKpi === BigInt(0)) {
+        return {
+          referrerId,
+          kpi: 0n,
+          referralCount: referrerReferrals[referrerId],
+          rewardAmount: '0',
+        }
+      }
       return {
         referrerId,
         kpi,
-        numReferrals: referrerReferrals[referrerId],
+        referralCount: referrerReferrals[referrerId],
         rewardAmount: rewards
           .times(kpi)
-          .div(totalKpi === BigInt(0) ? BigInt(1) : totalKpi)
+          .div(totalKpi)
           .toFixed(0, BigNumber.ROUND_DOWN),
       }
     },
@@ -64,7 +72,7 @@ export function calculateSqrtProportionalPrizeContest({
       return {
         referrerId,
         kpi: referrerKpis[referrerId],
-        numReferrals: referrerReferrals[referrerId],
+        referralCount: referrerReferrals[referrerId],
         rewardAmount: rewardAmount.toFixed(0, BigNumber.ROUND_DOWN),
       }
     },


### PR DESCRIPTION
We want to show the number of referrals per campaign per reward period, however Dune's live fetch has a 4MiB response [limit](https://docs.dune.com/query-engine/Functions-and-operators/live-fetch#limits). Unfortunately for more popular campaigns, any .json file that has one entry per user will probably exceed this limit. The kpi.json for celo pg campaign is over 6MB.

This PR adds a `numReferrals` property per builder in the rewards.json. This file is already uploaded during the upload CI job. The reward calculation scripts all need to calculate the raw kpi value per builder + the total kpi value, so i abstracted this logic to a function and added a step to also return the number of referrals.

Not included in this PR: number of referrals per network for Scout Game.

Related to ENG-444 and ENG-447