### PR TITLE
feat: Add total transaction count to celo-pg rewards json

### DIFF
--- a/scripts/calculateKpi.ts
+++ b/scripts/calculateKpi.ts
@@ -62,7 +62,7 @@ async function calculateKpiBatch({
           return null
         }
 
-        const { kpi, breakdown } = await calculateKpiHandlers[protocol]({
+        const { kpi, metadata } = await calculateKpiHandlers[protocol]({
           address: userAddress,
           // if the referral happened after the start of the period, only calculate KPI from the referral block onwards so that we exclude user activity before the referral
           startTimestamp:
@@ -77,7 +77,7 @@ async function calculateKpiBatch({
           referrerId,
           userAddress,
           kpi,
-          breakdown,
+          metadata,
         }
       },
     )

--- a/scripts/calculateKpi/protocols/arbitrum/index.ts
+++ b/scripts/calculateKpi/protocols/arbitrum/index.ts
@@ -1,6 +1,6 @@
 import { KpiResult, NetworkId } from '../../../types'
 import { getBlockRange } from '../utils/events'
-import { fetchTotalGasUsed } from '../utils/networks'
+import { fetchNetworkMetrics } from '../utils/networks'
 
 /**
  * Calculates gas usage for Arbitrum network activity.
@@ -59,7 +59,7 @@ export async function calculateKpi({
     endTimestampExclusive,
   })
 
-  const kpi = await fetchTotalGasUsed({
+  const { totalGasUsed: kpi } = await fetchNetworkMetrics({
     networkId: NetworkId['arbitrum-one'],
     users: [address],
     startBlock,

--- a/scripts/calculateKpi/protocols/celo-pg/index.ts
+++ b/scripts/calculateKpi/protocols/celo-pg/index.ts
@@ -1,7 +1,7 @@
 import { RedisClientType } from '@redis/client'
 import { KpiResult, NetworkId } from '../../../types'
 import { getBlockRange } from '../utils/events'
-import { fetchTotalGasUsed } from '../utils/networks'
+import { fetchTotalGasUsed, fetchTotalTransactions } from '../utils/networks'
 
 /**
  * Calculates gas usage for Celo public goods infrastructure activity.
@@ -63,11 +63,19 @@ export async function calculateKpi({
     redis,
   })
 
-  const kpi = await fetchTotalGasUsed({
-    networkId: NetworkId['celo-mainnet'],
-    users: [address],
-    startBlock,
-    endBlockExclusive,
-  })
-  return { kpi }
+  const [kpi, totalTransactions] = await Promise.all([
+    fetchTotalGasUsed({
+      networkId: NetworkId['celo-mainnet'],
+      users: [address],
+      startBlock,
+      endBlockExclusive,
+    }),
+    fetchTotalTransactions({
+      networkId: NetworkId['celo-mainnet'],
+      users: [address],
+      startBlock,
+      endBlockExclusive,
+    }),
+  ])
+  return { kpi, breakdown: { totalTransactions } }
 }

--- a/scripts/calculateKpi/protocols/celo-pg/index.ts
+++ b/scripts/calculateKpi/protocols/celo-pg/index.ts
@@ -1,7 +1,7 @@
 import { RedisClientType } from '@redis/client'
 import { KpiResult, NetworkId } from '../../../types'
 import { getBlockRange } from '../utils/events'
-import { fetchTotalGasUsed, fetchTotalTransactions } from '../utils/networks'
+import { fetchNetworkMetrics } from '../utils/networks'
 
 /**
  * Calculates gas usage for Celo public goods infrastructure activity.
@@ -63,19 +63,11 @@ export async function calculateKpi({
     redis,
   })
 
-  const [kpi, totalTransactions] = await Promise.all([
-    fetchTotalGasUsed({
-      networkId: NetworkId['celo-mainnet'],
-      users: [address],
-      startBlock,
-      endBlockExclusive,
-    }),
-    fetchTotalTransactions({
-      networkId: NetworkId['celo-mainnet'],
-      users: [address],
-      startBlock,
-      endBlockExclusive,
-    }),
-  ])
+  const { totalGasUsed: kpi, totalTransactions } = await fetchNetworkMetrics({
+    networkId: NetworkId['celo-mainnet'],
+    users: [address],
+    startBlock,
+    endBlockExclusive,
+  })
   return { kpi, metadata: { totalTransactions } }
 }

--- a/scripts/calculateKpi/protocols/celo-pg/index.ts
+++ b/scripts/calculateKpi/protocols/celo-pg/index.ts
@@ -77,5 +77,5 @@ export async function calculateKpi({
       endBlockExclusive,
     }),
   ])
-  return { kpi, breakdown: { totalTransactions } }
+  return { kpi, metadata: { totalTransactions } }
 }

--- a/scripts/calculateKpi/protocols/celoTransactions/index.ts
+++ b/scripts/calculateKpi/protocols/celoTransactions/index.ts
@@ -1,7 +1,7 @@
 import { RedisClientType } from '@redis/client'
 import { KpiResult, NetworkId } from '../../../types'
 import { getBlockRange } from '../utils/events'
-import { fetchTotalTransactions } from '../utils/networks'
+import { fetchNetworkMetrics } from '../utils/networks'
 
 /**
  * Calculates transaction count for Celo network activity.
@@ -62,7 +62,7 @@ export async function calculateKpi({
     redis,
   })
 
-  const kpi = await fetchTotalTransactions({
+  const { totalTransactions: kpi } = await fetchNetworkMetrics({
     networkId: NetworkId['celo-mainnet'],
     users: [address],
     startBlock,

--- a/scripts/calculateKpi/protocols/liskV0/index.ts
+++ b/scripts/calculateKpi/protocols/liskV0/index.ts
@@ -1,7 +1,7 @@
 import { RedisClientType } from '@redis/client'
 import { KpiResult, NetworkId } from '../../../types'
 import { getBlockRange } from '../utils/events'
-import { fetchTotalGasUsed } from '../utils/networks'
+import { fetchNetworkMetrics } from '../utils/networks'
 
 /**
  * Calculates gas usage for Lisk infrastructure activity.
@@ -63,7 +63,7 @@ export async function calculateKpi({
     redis,
   })
 
-  const kpi = await fetchTotalGasUsed({
+  const { totalGasUsed: kpi } = await fetchNetworkMetrics({
     networkId: NetworkId['lisk-mainnet'],
     users: [address],
     startBlock,

--- a/scripts/calculateKpi/protocols/scoutGameV0.ts
+++ b/scripts/calculateKpi/protocols/scoutGameV0.ts
@@ -99,5 +99,5 @@ export const calculateKpi: CalculateKpiFn<ScoutGameBreakdown> = async ({
       breakdown[kpiName] = item
     }
   })
-  return { kpi: totalTransactions, breakdown }
+  return { kpi: totalTransactions, metadata: breakdown }
 }

--- a/scripts/calculateKpi/protocols/scoutGameV0.ts
+++ b/scripts/calculateKpi/protocols/scoutGameV0.ts
@@ -1,6 +1,6 @@
 import { CalculateKpiFn, NetworkId } from '../../types'
 import { getBlockRange } from './utils/events'
-import { fetchTotalTransactions } from './utils/networks'
+import { fetchNetworkMetrics } from './utils/networks'
 
 type ScoutGameBreakdown = 'baseKpi' | 'celoKpi' | 'polygonKpi'
 
@@ -77,7 +77,7 @@ export const calculateKpi: CalculateKpiFn<ScoutGameBreakdown> = async ({
 
   const transactions = await Promise.all(
     networkIds.map((networkId, index) =>
-      fetchTotalTransactions({
+      fetchNetworkMetrics({
         networkId,
         users: [address],
         startBlock: blockRanges[index].startBlock,
@@ -93,10 +93,10 @@ export const calculateKpi: CalculateKpiFn<ScoutGameBreakdown> = async ({
     polygonKpi: 0,
   }
   transactions.forEach((item, index) => {
-    totalTransactions += item
+    totalTransactions += item.totalTransactions
     const kpiName = networkIdToKpiName[networkIds[index]]
     if (kpiName) {
-      breakdown[kpiName] = item
+      breakdown[kpiName] = item.totalTransactions
     }
   })
   return { kpi: totalTransactions, metadata: breakdown }

--- a/scripts/calculateKpi/protocols/utils/networks.test.ts
+++ b/scripts/calculateKpi/protocols/utils/networks.test.ts
@@ -1,4 +1,4 @@
-import { fetchTotalGasUsed } from './networks'
+import { fetchNetworkMetrics } from './networks'
 import { getHyperSyncClient } from '../../../utils'
 import { QueryResponse } from '@envio-dev/hypersync-client'
 import { NetworkId } from '../../../types'
@@ -20,7 +20,7 @@ function calculateExpected(transactions: { gasUsed: bigint }[]) {
   return transactions.reduce((acc, tx) => acc + Number(tx.gasUsed), 0)
 }
 
-describe('fetchTotalGasUsed', () => {
+describe('fetchNetworkMetrics', () => {
   const networkId: NetworkId = NetworkId['celo-mainnet']
   const users = ['0xUser1']
   let mockClient: { get: jest.Mock }
@@ -44,14 +44,14 @@ describe('fetchTotalGasUsed', () => {
       },
     } as QueryResponse)
 
-    const result = await fetchTotalGasUsed({
+    const result = await fetchNetworkMetrics({
       networkId,
       users,
       startBlock: 0,
       endBlockExclusive: 100,
     })
 
-    expect(result).toBe(
+    expect(result.totalGasUsed).toBe(
       calculateExpected([{ gasUsed: 64678n }, { gasUsed: 211128n }]),
     )
     expect(mockClient.get).toHaveBeenCalledTimes(1)
@@ -68,13 +68,13 @@ describe('fetchTotalGasUsed', () => {
       } as QueryResponse)
       .mockReturnValueOnce(mockResponse as QueryResponse)
 
-    const result = await fetchTotalGasUsed({
+    const result = await fetchNetworkMetrics({
       networkId,
       users,
       startBlock: 0,
     })
 
-    expect(result).toBe(
+    expect(result.totalGasUsed).toBe(
       calculateExpected([{ gasUsed: 64678n }, { gasUsed: 211128n }]),
     )
     expect(mockClient.get).toHaveBeenCalledTimes(2)
@@ -84,7 +84,7 @@ describe('fetchTotalGasUsed', () => {
     mockClient.get.mockRejectedValue(new Error('API failure'))
 
     await expect(
-      fetchTotalGasUsed({ networkId, users, startBlock: 0 }),
+      fetchNetworkMetrics({ networkId, users, startBlock: 0 }),
     ).rejects.toThrow('API failure')
     expect(mockClient.get).toHaveBeenCalledTimes(1)
   })
@@ -105,13 +105,13 @@ describe('fetchTotalGasUsed', () => {
       } as QueryResponse)
       .mockResolvedValueOnce(mockResponse as QueryResponse)
 
-    const result = await fetchTotalGasUsed({
+    const result = await fetchNetworkMetrics({
       networkId,
       users,
       startBlock: 0,
     })
 
-    expect(result).toBe(
+    expect(result.totalGasUsed).toBe(
       calculateExpected([{ gasUsed: 30000n }, { gasUsed: 60000n }]),
     )
     expect(mockClient.get).toHaveBeenCalledTimes(3)

--- a/scripts/calculateRewards/celoPG.ts
+++ b/scripts/calculateRewards/celoPG.ts
@@ -173,6 +173,23 @@ export async function main(args: ReturnType<typeof parseArgs>) {
     proportionLinear,
   })
 
+  const totalTransactionsPerReferrer: {
+    [referrerId: string]: number
+  } = {}
+
+  for (const { referrerId, metadata } of filteredKpiData) {
+    if (!metadata) continue
+
+    totalTransactionsPerReferrer[referrerId] =
+      (totalTransactionsPerReferrer[referrerId] ?? 0) +
+      (metadata['totalTransactions'] ?? 0)
+  }
+
+  const rewardsWithTotalTransactions = rewards.map((reward) => ({
+    ...reward,
+    totalTransactions: totalTransactionsPerReferrer[reward.referrerId],
+  }))
+
   createAddRewardSafeTransactionJSON({
     filePath: resultDirectory.safeTransactionsFilePath,
     rewardPoolAddress: REWARD_POOL_ADDRESS,
@@ -188,7 +205,7 @@ export async function main(args: ReturnType<typeof parseArgs>) {
     )
   }
 
-  await resultDirectory.writeRewards(rewards)
+  await resultDirectory.writeRewards(rewardsWithTotalTransactions)
 }
 
 // Only run main if this file is being executed directly

--- a/scripts/calculateRewards/celoPG.ts
+++ b/scripts/calculateRewards/celoPG.ts
@@ -185,7 +185,7 @@ export async function main(args: ReturnType<typeof parseArgs>) {
       (metadata['totalTransactions'] ?? 0)
   }
 
-  const rewardsWithTotalTransactions = rewards.map((reward) => ({
+  const rewardsWithMetadata = rewards.map((reward) => ({
     ...reward,
     totalTransactions: totalTransactionsPerReferrer[reward.referrerId],
   }))
@@ -205,7 +205,7 @@ export async function main(args: ReturnType<typeof parseArgs>) {
     )
   }
 
-  await resultDirectory.writeRewards(rewardsWithTotalTransactions)
+  await resultDirectory.writeRewards(rewardsWithMetadata)
 }
 
 // Only run main if this file is being executed directly

--- a/scripts/calculateRewards/proofOfImpact.ts
+++ b/scripts/calculateRewards/proofOfImpact.ts
@@ -88,6 +88,23 @@ async function main(args: ReturnType<typeof parseArgs>) {
     endTimestampExclusive,
   })
 
+  const totalTransactionsPerReferrer: {
+    [referrerId: string]: number
+  } = {}
+
+  for (const { referrerId, breakdown } of kpiData) {
+    if (!breakdown) continue
+
+    totalTransactionsPerReferrer[referrerId] =
+      (totalTransactionsPerReferrer[referrerId] ?? 0) +
+      (breakdown['totalTransactions'] ?? 0)
+  }
+
+  const rewardsWithTotalTransactions = rewards.map((reward) => ({
+    ...reward,
+    totalTransactions: totalTransactionsPerReferrer[reward.referrerId],
+  }))
+
   createAddRewardSafeTransactionJSON({
     filePath: resultDirectory.safeTransactionsFilePath,
     rewardPoolAddress: REWARD_POOL_ADDRESS,
@@ -96,7 +113,7 @@ async function main(args: ReturnType<typeof parseArgs>) {
     endTimestampExclusive,
   })
 
-  await resultDirectory.writeRewards(rewards)
+  await resultDirectory.writeRewards(rewardsWithTotalTransactions)
 }
 
 // Only run main if this file is being executed directly

--- a/scripts/calculateRewards/proofOfImpact.ts
+++ b/scripts/calculateRewards/proofOfImpact.ts
@@ -88,23 +88,6 @@ async function main(args: ReturnType<typeof parseArgs>) {
     endTimestampExclusive,
   })
 
-  const totalTransactionsPerReferrer: {
-    [referrerId: string]: number
-  } = {}
-
-  for (const { referrerId, breakdown } of kpiData) {
-    if (!breakdown) continue
-
-    totalTransactionsPerReferrer[referrerId] =
-      (totalTransactionsPerReferrer[referrerId] ?? 0) +
-      (breakdown['totalTransactions'] ?? 0)
-  }
-
-  const rewardsWithTotalTransactions = rewards.map((reward) => ({
-    ...reward,
-    totalTransactions: totalTransactionsPerReferrer[reward.referrerId],
-  }))
-
   createAddRewardSafeTransactionJSON({
     filePath: resultDirectory.safeTransactionsFilePath,
     rewardPoolAddress: REWARD_POOL_ADDRESS,
@@ -113,7 +96,7 @@ async function main(args: ReturnType<typeof parseArgs>) {
     endTimestampExclusive,
   })
 
-  await resultDirectory.writeRewards(rewardsWithTotalTransactions)
+  await resultDirectory.writeRewards(rewards)
 }
 
 // Only run main if this file is being executed directly

--- a/scripts/calculateRewards/scoutGameV0.ts
+++ b/scripts/calculateRewards/scoutGameV0.ts
@@ -90,14 +90,14 @@ export async function main(args: ReturnType<typeof parseArgs>) {
     [referrerId: string]: { [key: string]: bigint }
   } = {}
 
-  for (const { referrerId, breakdown } of kpiData) {
-    if (!breakdown) continue
+  for (const { referrerId, metadata } of kpiData) {
+    if (!metadata) continue
 
     if (!segmentedKpiPerReferrer[referrerId]) {
       segmentedKpiPerReferrer[referrerId] = {}
     }
 
-    for (const [key, value] of Object.entries(breakdown)) {
+    for (const [key, value] of Object.entries(metadata)) {
       segmentedKpiPerReferrer[referrerId][key] =
         (segmentedKpiPerReferrer[referrerId][key] ?? 0n) + BigInt(value)
     }

--- a/scripts/types.ts
+++ b/scripts/types.ts
@@ -51,13 +51,13 @@ export interface TokenPriceData {
 /**
  * Represents the result of a KPI computation.
  *
- * @template T - The allowed string keys for the breakdown.
+ * @template T - The allowed string keys for the metadata.
  * - `kpi`: overall KPI value.
- * - `breakdown`: an optional map from typed segment keys to their KPI values.
+ * - `metadata`: an optional map from typed segment keys to their KPI values.
  */
 export interface KpiResult<T extends string = string> {
   kpi: number
-  breakdown?: Record<T, number>
+  metadata?: Record<T, number>
 }
 
 export type CalculateKpiFn<T extends string = string> = (params: {

--- a/src/resultDirectory.ts
+++ b/src/resultDirectory.ts
@@ -9,7 +9,7 @@ export interface KpiRow {
   referrerId: string
   userAddress: string
   kpi: string
-  breakdown?: { [key: string]: number }
+  metadata?: { [key: string]: number }
 }
 
 interface ReferralRow {


### PR DESCRIPTION
Updated `breakdown` to `metadata` to be more generic with what it will have (not just a breakdown of kpi, in this case is # transaction when kpi is gas).

**Manual testing:**
```
ts-node scripts/uploadCurrentPeriodKpis.ts --dry-run --protocol celo-pg
```
```
[
...
  {
    "referrerId": "0xe6e6c0ddf053822bbbc1f39218f30ea25fca58dd",
    "rewardAmount": "176398364831532259500",
    "referralCount": 7925,
    "kpi": "47323465",
    "linearProportion": "0.00352796",
    "powerProportion": "0.03962855",
    "linearReward": "176398364831532259500.00000000",
    "powerReward": "0.00000000",
    "totalTransactions": 865
  },
  {
    "referrerId": "0x99342d3ce2d10c34b7d20d960ea75bd742aec468",
    "rewardAmount": "39195206284652732500",
    "referralCount": 68,
    "kpi": "10515137",
    "linearProportion": "0.00078390",
    "powerProportion": "0.01868002",
    "linearReward": "39195206284652732500.00000000",
    "powerReward": "0.00000000",
    "totalTransactions": 45
  },
...
]
```