### PR TITLE
chore: add slack notification on kpi upload CI failure

### DIFF
--- a/.github/workflows/calculate-and-upload-KPIs.yaml
+++ b/.github/workflows/calculate-and-upload-KPIs.yaml
@@ -10,7 +10,6 @@ on:
         required: true
       protocol:
         description: 'Protocol to calculate KPIs for, e.g. celo-pg, scout-game-v0, lisk-v0'
-  pull_request:
 
 # Cancel same in progress run(s) of the workflow to avoid uploading outdated KPIs
 concurrency:
@@ -22,27 +21,27 @@ jobs:
     name: Calculate and Upload KPIs
     runs-on: ubuntu-latest
     steps:
-      # - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      # - uses: google-github-actions/auth@ba79af03959ebeac9769e648f473a284504d9193 # v2.1.10
-      #   with:
-      #     project_id: divvi-production
-      #     credentials_json: ${{ secrets.DIVVI_PRODUCTION_UPLOADER_SERVICE_ACCOUNT_KEY }}
-      # - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-      #   with:
-      #     node-version-file: 'package.json'
-      #     check-latest: true
-      # - run: yarn
-      # - name: Calculate and upload KPIs for the current reward period
-      #   run: |
-      #     yarn ts-node scripts/uploadCurrentPeriodKpis.ts \
-      #       --calculation-timestamp ${{ github.event.inputs.timestamp }} \
-      #       --protocol ${{ github.event.inputs.protocol }} \
-      #       --redis-connection ${{ secrets.REDIS_CONNECTION }}
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: google-github-actions/auth@ba79af03959ebeac9769e648f473a284504d9193 # v2.1.10
+        with:
+          project_id: divvi-production
+          credentials_json: ${{ secrets.DIVVI_PRODUCTION_UPLOADER_SERVICE_ACCOUNT_KEY }}
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version-file: 'package.json'
+          check-latest: true
+      - run: yarn
+      - name: Calculate and upload KPIs for the current reward period
+        run: |
+          yarn ts-node scripts/uploadCurrentPeriodKpis.ts \
+            --calculation-timestamp ${{ github.event.inputs.timestamp }} \
+            --protocol ${{ github.event.inputs.protocol }} \
+            --redis-connection ${{ secrets.REDIS_CONNECTION }}
       - name: Notify Slack on Failure
-        # if: failure()
+        if: failure()
         uses: slackapi/slack-github-action@v2.1.0
         with:
           webhook: ${{ secrets.SLACK_ON_CALL_WEBHOOK_URL }}
           webhook-type: incoming-webhook
           payload: |
-            text: "❌ <!subteam^S0277QUM4KB> The periodic KPI calculation and upload workflow failed! Please check the run details: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            text: "⚠️ <!subteam^S0277QUM4KB> The periodic KPI calculation and upload workflow failed! Please check the run details: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/calculate-and-upload-KPIs.yaml
+++ b/.github/workflows/calculate-and-upload-KPIs.yaml
@@ -10,6 +10,7 @@ on:
         required: true
       protocol:
         description: 'Protocol to calculate KPIs for, e.g. celo-pg, scout-game-v0, lisk-v0'
+  pull_request:
 
 # Cancel same in progress run(s) of the workflow to avoid uploading outdated KPIs
 concurrency:
@@ -21,24 +22,24 @@ jobs:
     name: Calculate and Upload KPIs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: google-github-actions/auth@ba79af03959ebeac9769e648f473a284504d9193 # v2.1.10
-        with:
-          project_id: divvi-production
-          credentials_json: ${{ secrets.DIVVI_PRODUCTION_UPLOADER_SERVICE_ACCOUNT_KEY }}
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-        with:
-          node-version-file: 'package.json'
-          check-latest: true
-      - run: yarn
-      - name: Calculate and upload KPIs for the current reward period
-        run: |
-          yarn ts-node scripts/uploadCurrentPeriodKpis.ts \
-            --calculation-timestamp ${{ github.event.inputs.timestamp }} \
-            --protocol ${{ github.event.inputs.protocol }} \
-            --redis-connection ${{ secrets.REDIS_CONNECTION }}
+      # - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      # - uses: google-github-actions/auth@ba79af03959ebeac9769e648f473a284504d9193 # v2.1.10
+      #   with:
+      #     project_id: divvi-production
+      #     credentials_json: ${{ secrets.DIVVI_PRODUCTION_UPLOADER_SERVICE_ACCOUNT_KEY }}
+      # - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      #   with:
+      #     node-version-file: 'package.json'
+      #     check-latest: true
+      # - run: yarn
+      # - name: Calculate and upload KPIs for the current reward period
+      #   run: |
+      #     yarn ts-node scripts/uploadCurrentPeriodKpis.ts \
+      #       --calculation-timestamp ${{ github.event.inputs.timestamp }} \
+      #       --protocol ${{ github.event.inputs.protocol }} \
+      #       --redis-connection ${{ secrets.REDIS_CONNECTION }}
       - name: Notify Slack on Failure
-        if: failure()
+        # if: failure()
         uses: slackapi/slack-github-action@v2.1.0
         with:
           webhook: ${{ secrets.SLACK_ON_CALL_WEBHOOK_URL }}

--- a/.github/workflows/calculate-and-upload-KPIs.yaml
+++ b/.github/workflows/calculate-and-upload-KPIs.yaml
@@ -37,13 +37,11 @@ jobs:
             --calculation-timestamp ${{ github.event.inputs.timestamp }} \
             --protocol ${{ github.event.inputs.protocol }} \
             --redis-connection ${{ secrets.REDIS_CONNECTION }}
-
-      # TODO(kathy)
-      # - name: Notify Slack on Failure
-      #   if: failure()
-      #   uses: slackapi/slack-github-action@v1.25.0
-      #   with:
-      #     channel-id: 'alerts'
-      #     slack-message: '❌ KPI calculation and upload workflow failed! Check the run details: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
-      #   env:
-      #     SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+      - name: Notify Slack on Failure
+        if: failure()
+        uses: slackapi/slack-github-action@v2.1.0
+        with:
+          webhook: ${{ secrets.SLACK_ON_CALL_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            text: "❌ <!subteam^S0277QUM4KB> The periodic KPI calculation and upload workflow failed! Please check the run details: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/calculate-and-upload-KPIs.yaml
+++ b/.github/workflows/calculate-and-upload-KPIs.yaml
@@ -44,4 +44,4 @@ jobs:
           webhook: ${{ secrets.SLACK_ON_CALL_WEBHOOK_URL }}
           webhook-type: incoming-webhook
           payload: |
-            text: "⚠️ <!subteam^S0277QUM4KB> The periodic KPI calculation and upload workflow failed! Please check the run details: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            text: "⚠️ <!subteam^S0277QUM4KB> Periodic KPI calculation and upload workflow failed! The next scheduled run will automatically backfill any missed data, so single failures are generally not a concern. If failures continue, please review the run details: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"


### PR DESCRIPTION
This PR adds a slack notification to the on-call slack channel when the periodic kpi calculation and upload CI fails. I've been keeping an eye on this workflow for the last few weeks and it is quite stable, so I don't expect this alert to fire often.

I followed the integration steps [here](https://tools.slack.dev/slack-github-action/sending-techniques/sending-data-slack-incoming-webhook/post-inline-text-message). Example of slack alert is [here](https://valora-app.slack.com/archives/C02N3AR2P2S/p1750245850795729).

Fixes ENG-392