### PR TITLE
feat: upload safe txs in CI

### DIFF
--- a/scripts/uploadCurrentPeriodKpis.ts
+++ b/scripts/uploadCurrentPeriodKpis.ts
@@ -404,7 +404,12 @@ export async function uploadCurrentPeriodKpis(
       })
       const rewardsFilePathCsv = join(outputDir, 'rewards.csv')
       const rewardsFilePathJson = join(outputDir, 'rewards.json')
-      campaignFilePaths.push(rewardsFilePathCsv, rewardsFilePathJson)
+      const safeTransactionsJson = join(outputDir, 'safe-transactions.json')
+      campaignFilePaths.push(
+        rewardsFilePathCsv,
+        rewardsFilePathJson,
+        safeTransactionsJson,
+      )
     }
 
     const validPaths = campaignFilePaths.filter((path) => path !== null)


### PR DESCRIPTION
This change uploads the generated safe-transactions.json file during the kpi calculation CI workflow. For campaigns that do not require an inclusion list at the time of reward calculation (i.e. all current campaigns), this change makes it so that you can download the file from the CI directly without having to run any scripts locally. One less step for reward distributions :) 