### PR TITLE
fix: ensure supported networks have viem client config

### DIFF
--- a/scripts/calculateKpi/protocols/tetherV0/parseReferralTag/getTransactionInfo.ts
+++ b/scripts/calculateKpi/protocols/tetherV0/parseReferralTag/getTransactionInfo.ts
@@ -1,12 +1,12 @@
 import {
   Address,
   Hex,
-  PublicClient,
   TransactionNotFoundError,
   TransactionReceiptNotFoundError,
   Hash,
 } from 'viem'
 import { getUserOperations, UserOperationWithHash } from './getUserOperations'
+import { getViemPublicClient } from '../../../../utils'
 
 // Discriminated union for transaction info
 export type TransactionInfo = {
@@ -35,7 +35,7 @@ export async function getTransactionInfo({
   delayFn = delay, // facilitates testing
   skipRetries = false,
 }: {
-  publicClient: PublicClient
+  publicClient: ReturnType<typeof getViemPublicClient>
   txHash: Hex
   delayFn?: (ms: number) => Promise<void>
   skipRetries?: boolean

--- a/scripts/calculateKpi/protocols/utils/events.ts
+++ b/scripts/calculateKpi/protocols/utils/events.ts
@@ -9,9 +9,9 @@ import Bottleneck from 'bottleneck'
 
 const DEFI_LLAMA_API_URL = 'https://coins.llama.fi'
 
-const NETWORK_ID_TO_DEFI_LLAMA_CHAIN: Partial<{
+const NETWORK_ID_TO_DEFI_LLAMA_CHAIN: {
   [networkId in NetworkId]: string // eslint-disable-line @typescript-eslint/no-unused-vars
-}> = {
+} = {
   [NetworkId['ethereum-mainnet']]: 'ethereum',
   [NetworkId['arbitrum-one']]: 'arbitrum',
   [NetworkId['op-mainnet']]: 'optimism',

--- a/scripts/utils/networks.ts
+++ b/scripts/utils/networks.ts
@@ -1,4 +1,3 @@
-import { Address } from 'viem'
 import { NetworkId } from '../types'
 import {
   arbitrum,
@@ -15,15 +14,6 @@ import {
   mainnet,
   mantle,
 } from 'viem/chains'
-
-export const NETWORK_ID_TO_REGISTRY_ADDRESS = {
-  [NetworkId['arbitrum-one']]: '0xBa9655677f4E42DD289F5b7888170bC0c7dA8Cdc',
-  [NetworkId['base-mainnet']]: '0xBa9655677f4E42DD289F5b7888170bC0c7dA8Cdc',
-  [NetworkId['celo-mainnet']]: '0xBa9655677f4E42DD289F5b7888170bC0c7dA8Cdc',
-  [NetworkId['op-mainnet']]: '0xBa9655677f4E42DD289F5b7888170bC0c7dA8Cdc',
-  [NetworkId['polygon-pos-mainnet']]:
-    '0xBa9655677f4E42DD289F5b7888170bC0c7dA8Cdc',
-} as Partial<Record<NetworkId, Address>>
 
 export const supportedNetworkIds = [
   NetworkId['arbitrum-one'],


### PR DESCRIPTION
I forgot to add viem client config for the new networks supported by the Tether campaign. I expected typescript to help us with where to add config, but this `Partial` type got in the way. This PR removes `Partial` as much as possible, and adds the missing viem client config.