### PR TITLE
chore: silence consoles in getReferrerIdFromTx.ts

### DIFF
--- a/scripts/calculateKpi/protocols/tetherV0/parseReferralTag/getReferrerIdFromTx.ts
+++ b/scripts/calculateKpi/protocols/tetherV0/parseReferralTag/getReferrerIdFromTx.ts
@@ -19,7 +19,6 @@ export async function getReferrerIdFromTx(
       skipRetries,
     })
   } catch (error) {
-    console.warn('No transaction info found for tx', txHash, error)
     return null
   }
 
@@ -37,12 +36,11 @@ export async function getReferrerIdFromTx(
         user: transactionInfo.from,
       }
 
-  const { referral, error } = parseReferral(parseReferralParams)
+  const { referral } = parseReferral(parseReferralParams)
 
   if (referral) {
     return referral.consumer
   }
 
-  console.warn('No referral found for tx', txHash, error)
   return null
 }


### PR DESCRIPTION
We expect this to fail often so the console.warns aren't very helpful